### PR TITLE
Added mobile version of session run, fixed many small bugs

### DIFF
--- a/imports/api/questions.js
+++ b/imports/api/questions.js
@@ -292,12 +292,15 @@ Meteor.methods({
     const session = Sessions.findOne({ _id: sessionId })
     const question = Questions.findOne({ _id: questionId })
 
+    if(!question || !session) return
+
     question.originalQuestion = questionId
     question.sessionId = sessionId
     question.courseId = session.courseId
     question.owner = Meteor.userId()
+    //question.sessionOptions = defaultSessionOptions
 
-    const copiedQuestion = Meteor.call('questions.insert', _(question).omit(['_id', 'createdAt']))
+    const copiedQuestion = Meteor.call('questions.insert', _(question).omit(['_id', 'createdAt', 'sessionOptions']))
     Meteor.call('sessions.addQuestion', sessionId, copiedQuestion._id)
     return copiedQuestion._id
   },

--- a/imports/api/questions.js
+++ b/imports/api/questions.js
@@ -454,6 +454,7 @@ Meteor.methods({
    * @param {MongoId} questionId
    */
   'questions.startAttempt' (questionId) {
+    if(!questionId) return
     check(questionId, Helpers.MongoID)
     const q = Questions.findOne({ _id: questionId })
     if (!Meteor.user().isInstructor(q.courseId)) throw Error('Not authorized')
@@ -536,6 +537,7 @@ Meteor.methods({
    * disables visibility of entire question in session
    */
   'questions.hideQuestion' (questionId) {
+    if(!questionId) return
     check(questionId, Helpers.MongoID)
     const q = Questions.findOne({ _id: questionId })
     if (!Meteor.user().isInstructor(q.courseId)) throw Error('Not authorized')

--- a/imports/api/sessions.js
+++ b/imports/api/sessions.js
@@ -188,7 +188,8 @@ Meteor.methods({
     // modify session
     session.status = 'hidden'
     session.name += ' (copy)'
-
+    session.reviewable = false
+    
     // keep a copy of the questions
     const questions = (session.questions || []).slice()
     session.questions = []

--- a/imports/startup/client/routes.jsx
+++ b/imports/startup/client/routes.jsx
@@ -337,6 +337,21 @@ Router.route('/session/run/:_id', {
   }
 })
 
+
+Router.route('/session/run/:_id/mobile', {
+  name: 'session.run.mobile',
+  waitOn: function () {
+    return Meteor.subscribe('userData') && Meteor.subscribe('sessions') && Meteor.subscribe('courses') && Meteor.subscribe('questions.inSession', this.params._id)
+  },
+  action: function () {
+    const sess = Sessions.findOne(this.params._id)
+    const cId = sess ? sess.courseId : ''
+    if (Meteor.userId() && Meteor.user().isInstructor(cId)) {
+      mount(AppLayout, { content:  <RunSession mobile sessionId={this.params._id} courseId={cId} /> })
+    } else Router.go('login')
+  }
+})
+
 import { Session } from '../../ui/pages/student/session'
 Router.route('/session/present/:_id', {
   name: 'session',

--- a/imports/ui/QuestionDisplay.jsx
+++ b/imports/ui/QuestionDisplay.jsx
@@ -253,7 +253,9 @@ export class _QuestionDisplay extends Component {
         if (a.wysiwyg) content = this.wysiwygContent(a.answer, a.content, a.correct)
         else content = this.commonContent(classSuffixStr, a.answer, a.content, a.correct)
 
-        if (!this.props.noStats && this.props.question.sessionOptions && this.props.question.sessionOptions.stats) {
+        let showStats = !this.props.noStats && this.props.question.sessionOptions && this.props.question.sessionOptions.stats
+        if(this.props.showStatsOverride) showStats = true
+        if (showStats) {
           stats = this.calculateStats(a.answer)
 
           if (stats > 0) {
@@ -268,8 +270,10 @@ export class _QuestionDisplay extends Component {
 
           widthStyle = { width: stats + '%' }
         }
+        const statsStr = '('+stats+'%)'
         const sess = this.props.question.sessionOptions
         const shouldShow = this.props.forReview || this.props.prof || (sess && sess.correct)
+
         return (
           <div key={'question_' + a.answer}
             onClick={() => this.setAnswer(a.answer)}
@@ -278,9 +282,10 @@ export class _QuestionDisplay extends Component {
               ? 'q-submitted' : '')} >
             <div className={statClass} style={widthStyle}>&nbsp;</div>
             <div className='answer-container'>
-              { classSuffixStr === 'mc' || classSuffixStr === 'ms'
-                ? <span className='ql-mc'>{a.answer}.</span> : '' }
-              {content} {(shouldShow && a.correct) ? '✓' : ''}
+              { classSuffixStr === 'mc' || classSuffixStr === 'ms' ?
+                 <span className='ql-mc'>{a.answer}.</span>
+                 : '' }
+              {content} {(shouldShow && a.correct) ? '✓' : ''} {showStats ? statsStr: ''}
             </div>
           </div>)
       })
@@ -404,7 +409,8 @@ export const QuestionDisplay = createContainer((props) => {
 QuestionDisplay.propTypes = {
   question: PropTypes.object.isRequired,
   readonly: PropTypes.bool,
-  noStats: PropTypes.bool,
+  noStats: PropTypes.bool, //seems confusing...
+  showStatsOverride: PropTypes.bool, //used for mobile session running
   prof: PropTypes.bool,
   forReview: PropTypes.bool
 }

--- a/imports/ui/QuestionDisplay.jsx
+++ b/imports/ui/QuestionDisplay.jsx
@@ -214,7 +214,7 @@ export class _QuestionDisplay extends Component {
   wysiwygContent (answer, content, correct) {
     let classContent = 'ql-wysiwyg-content'
 
-    if (!this.props.noStats && this.props.question.sessionOptions.correct) {
+    if (!this.props.noStats && this.props.question.sessionOptions && this.props.question.sessionOptions.correct) {
       classContent = correct ? 'ql-wysiwyg-content correct-color' : 'ql-wysiwyg-content incorrect-color'
     }
     return (
@@ -232,7 +232,7 @@ export class _QuestionDisplay extends Component {
    */
   commonContent (typeStr, answer, content, correct) {
     let classContent = ''
-    if (!this.props.noStats && this.props.question.sessionOptions.correct) {
+    if (!this.props.noStats && this.props.question.sessionOptions && this.props.question.sessionOptions.correct) {
       classContent = correct ? 'correct-color' : 'incorrect-color'
     }
     return (
@@ -253,7 +253,7 @@ export class _QuestionDisplay extends Component {
         if (a.wysiwyg) content = this.wysiwygContent(a.answer, a.content, a.correct)
         else content = this.commonContent(classSuffixStr, a.answer, a.content, a.correct)
 
-        if (!this.props.noStats && this.props.question.sessionOptions.stats) {
+        if (!this.props.noStats && this.props.question.sessionOptions && this.props.question.sessionOptions.stats) {
           stats = this.calculateStats(a.answer)
 
           if (stats > 0) {
@@ -307,7 +307,7 @@ export class _QuestionDisplay extends Component {
   render () {
     if (this.props.loading) return <div className='ql-subs-loading'>Loading</div>
 
-    if (!this.props.noStats && this.props.question.sessionOptions.hidden) return <div className='ql-subs-loading'>Waiting for a Question...</div>
+    if (!this.props.noStats && this.props.question.sessionOptions && this.props.question.sessionOptions.hidden) return <div className='ql-subs-loading'>Waiting for a Question...</div>
 
     const q = this.props.question
     const type = q.type
@@ -360,7 +360,7 @@ export const QuestionDisplay = createContainer((props) => {
   let responses
 
   const question = props.question
-  if (!props.noStats && question.type !== QUESTION_TYPE.SA) {
+  if (!props.noStats && question.type !== QUESTION_TYPE.SA && question.sessionOptions) {
     //Get the number of last attempt
     const attemptNumber = question.sessionOptions.attempts.length
     //Get the responses for that attempt:

--- a/imports/ui/QuestionDisplay.jsx
+++ b/imports/ui/QuestionDisplay.jsx
@@ -296,7 +296,7 @@ export class _QuestionDisplay extends Component {
     if (this.props.forReview) return <h4 style={{'alignSelf': 'left'}}>{q.options[0].plainText}</h4>
     let showAns = !this.props.prof && (q.sessionOptions && q.sessionOptions.correct) && q.options[0].plainText
     return (
-      <div className='ql-short-answer'>
+      <div className='ql-answer-content-container ql-short-answer'>
         { showAns ? <h4>Correct Answer: {WysiwygHelper.htmlDiv(q.options[0].content)}</h4> : ''}
         <textarea
           disabled={this.readonly}

--- a/imports/ui/QuestionDisplay.jsx
+++ b/imports/ui/QuestionDisplay.jsx
@@ -293,7 +293,17 @@ export class _QuestionDisplay extends Component {
   }
 
   renderShortAnswer (q) {
-    if (this.props.forReview) return <h4 style={{'alignSelf': 'left'}}>{q.options[0].plainText}</h4>
+    if ((this.props.forReview || this.props.prof)){
+      //return <h4 style={{'alignSelf': 'left'}}>{q.options[0].plainText}</h4>
+      return (
+        <div>
+        {q.options[0].content ?
+          <h4 style={{'alignSelf': 'left'}}>{WysiwygHelper.htmlDiv(q.options[0].content)}</h4>
+          :''
+        }</div>
+    )}
+
+
     let showAns = !this.props.prof && (q.sessionOptions && q.sessionOptions.correct) && q.options[0].plainText
     return (
       <div className='ql-answer-content-container ql-short-answer'>

--- a/imports/ui/QuestionSidebar.jsx
+++ b/imports/ui/QuestionSidebar.jsx
@@ -144,17 +144,21 @@ export class QuestionSidebar extends ControlledForm {
     }
   }
   /**
-   * Set approved status to true
+   * Set approved status to true and take ownership
    * @param {MongoId} questionId
    */
+   //TODO: by unapproving and then approving a question, you can thus steal the ownership
+   //not clear how to make this better.
   approveQuestion(questionId){
     if (confirm('Are you sure?')) {
       question = this.state.questionPool.find((q)=>{return q._id===questionId})
-      if(question){
+      userId = Meteor.userId()
+      if(question && userId){
         question.approved = true
+        question.owner = userId
         Meteor.call('questions.update', question, (error, newQuestionId) => {
           if (error) return alertify.error('Error: ' + error.error)
-          alertify.success('Question un-approved')
+          alertify.success('Question approved')
         })
     }
     }

--- a/imports/ui/ShortAnswerList.jsx
+++ b/imports/ui/ShortAnswerList.jsx
@@ -14,12 +14,24 @@ import { Responses } from '../api/responses'
  */
 class _ShortAnswerList extends Component {
 
+  renderAnswer(r){
+    const user = Meteor.users.findOne(r.studentUserId)
+    const name = user? user.getName() : 'Unknown'
+
+    return(
+      <div>
+        {name}: {r.answer}
+      </div>
+    )
+
+  }
+
   render () {
     if (this.props.loading) return <div>Loading</div>
     return (<div className='ql-short-answer-list'>
       <h3>Responses</h3>
       {
-        this.props.responses.map(r => <div className='ql-short-answer-item'>{r.answer}</div>)
+        this.props.responses.map(r => <div key={r._id} className='ql-short-answer-item'>{this.renderAnswer(r)}</div>)
       }
     </div>)
   } //  end render
@@ -28,7 +40,11 @@ class _ShortAnswerList extends Component {
 
 export const ShortAnswerList = createContainer((props) => {
   const handle = Meteor.subscribe('responses.forQuestion', props.question._id)
-  const responses = Responses.find({ questionId: props.question._id }, { sort: { createdAt: -1 } }).fetch()
+  const question = props.question
+  const attemptNumber = question.sessionOptions.attempts.length
+  //Get the responses for that attempt:
+  const responses = Responses.find({ questionId: question._id, attempt: attemptNumber }, { sort: { createdAt: -1 } }).fetch()
+  //const responses = Responses.find({ questionId: props.question._id }, { sort: { createdAt: -1 } }).fetch()
 
   return {
     responses: responses,
@@ -39,4 +55,3 @@ export const ShortAnswerList = createContainer((props) => {
 ShortAnswerList.propTypes = {
   question: PropTypes.object.isRequired
 }
-

--- a/imports/ui/StudentQuestionResultsClassList.jsx
+++ b/imports/ui/StudentQuestionResultsClassList.jsx
@@ -42,11 +42,14 @@ export class _StudentQuestionResultsClassList extends Component {
       </tr>)
     })
 
+    //TODO This should use bootstrap to decide on width
+    //<div style={{float: 'left', width: '50%'}}>
+    //<div style={{float: 'right', width: '50%'}}>
     return (<div className='ql-student-results-list'>
-      <div style={{float: 'left', width: '50%'}}>
+      <div className='col-sm-8'>
         <QuestionDisplay style={{float: 'right'}} question={q} readonly noStats forReview />
       </div>
-      <div style={{float: 'right', width: '50%'}}>
+      <div className='col-sm-4'>
         <table style={{float: 'right', margin: '15px'}} className='ql-student-results-table'>
           <thead>
             <tr>
@@ -77,4 +80,3 @@ export const StudentQuestionResultsClassList = createContainer((props) => {
 StudentQuestionResultsClassList.propTypes = {
   question: PropTypes.object.isRequired
 }
-

--- a/imports/ui/StudentQuestionResultsClassList.jsx
+++ b/imports/ui/StudentQuestionResultsClassList.jsx
@@ -42,9 +42,6 @@ export class _StudentQuestionResultsClassList extends Component {
       </tr>)
     })
 
-    //TODO This should use bootstrap to decide on width
-    //<div style={{float: 'left', width: '50%'}}>
-    //<div style={{float: 'right', width: '50%'}}>
     return (<div className='ql-student-results-list'>
       <div className='col-sm-8'>
         <QuestionDisplay style={{float: 'right'}} question={q} readonly noStats forReview />

--- a/imports/ui/StudentQuestionResultsListItem.jsx
+++ b/imports/ui/StudentQuestionResultsListItem.jsx
@@ -19,7 +19,7 @@ export class StudentQuestionResultsListItem extends Component {
 
   render () {
     const q = this.props.question
-    const attempts = 'Attempts: ' + q.studentResponses.length + '/' + (q.sessionOptions.attempts ? q.sessionOptions.attempts.length : 0)
+    const attempts = 'Attempts: ' + q.studentResponses.length + '/' + (q.sessionOptions && q.sessionOptions.attempts ? q.sessionOptions.attempts.length : 0)
     return (<div className='ql-results-list-item ql-list-item'>
       <span>{(this.props.session.questions.indexOf(q._id) + 1) + '.'}</span>
       <span className='title'>{WysiwygHelper.htmlDiv(q.content)}</span>
@@ -33,4 +33,3 @@ StudentQuestionResultsListItem.propTypes = {
   question: PropTypes.object.isRequired,
   session: PropTypes.object.isRequired
 }
-

--- a/imports/ui/pages/professor/manage_course.jsx
+++ b/imports/ui/pages/professor/manage_course.jsx
@@ -257,6 +257,7 @@ class _ManageCourse extends Component {
     const toggleAddTA = () => { this.setState({ addTAModal: !this.state.addTAModal }) }
     const toggleAddStudent = () => { this.setState({ addStudentModal: !this.state.addStudentModal }) }
     const toggleExpandedClasslist = () => { this.setState({ expandedClasslist: !this.state.expandedClasslist }) }
+    const expandText = !this.state.expandedClasslist ? 'show all' : 'show less'
 
     const strActive = this.props.course.inactive ? 'Enable Course' : 'Archive Course'
     return (
@@ -304,7 +305,7 @@ class _ManageCourse extends Component {
 
             <div className='ql-card hidden-xs'>
               <div className='ql-header-bar' onClick={toggleExpandedClasslist}>
-                <h4>Classlist ({this.props.course.students.length} student{this.props.course.students.length>1?'s':''})</h4>
+                <h4>{this.props.course.students.length} student{this.props.course.students.length>1?'s':''} (click to {expandText})</h4>
               </div>
               <div>
                 <div className='ql-course-classlist'>
@@ -312,7 +313,6 @@ class _ManageCourse extends Component {
                 </div>
               </div>
             </div>
-
           </div>
 
           <div className='col-md-8'>

--- a/imports/ui/pages/professor/manage_course.jsx
+++ b/imports/ui/pages/professor/manage_course.jsx
@@ -256,6 +256,7 @@ class _ManageCourse extends Component {
     const toggleCreatingSession = () => { this.setState({ creatingSession: !this.state.creatingSession }) }
     const toggleAddTA = () => { this.setState({ addTAModal: !this.state.addTAModal }) }
     const toggleAddStudent = () => { this.setState({ addStudentModal: !this.state.addStudentModal }) }
+    const toggleExpandedClasslist = () => { this.setState({ expandedClasslist: !this.state.expandedClasslist }) }
 
     const strActive = this.props.course.inactive ? 'Enable Course' : 'Archive Course'
     return (
@@ -302,7 +303,7 @@ class _ManageCourse extends Component {
             </div>
 
             <div className='ql-card hidden-xs'>
-              <div className='ql-header-bar'>
+              <div className='ql-header-bar' onClick={toggleExpandedClasslist}>
                 <h4>Classlist ({this.props.course.students.length} student{this.props.course.students.length>1?'s':''})</h4>
               </div>
               <div>

--- a/imports/ui/pages/professor/run_session.jsx
+++ b/imports/ui/pages/professor/run_session.jsx
@@ -245,6 +245,7 @@ class _RunSession extends Component {
     }
   }
   renderMobile(){
+    //TODO: Add some styling... this is barebones and needs some css to look nicer...
 
     if (this.state.session.status !== 'running') return <div className='ql-subs-loading'>Session not running</div>
     const current = this.state.session.currentQuestion
@@ -275,7 +276,7 @@ class _RunSession extends Component {
         Question: {questionList.indexOf(current) + 1}/{questionList.length}&nbsp;&nbsp;
         Responses: <span className='glyphicon glyphicon-check' />&nbsp;{numAnswered}/{numJoined}&nbsp;&nbsp;
         Attempt: {q.sessionOptions.attempts.length}
-        <div className='btn-group-lg btn-group-justified details-button-group'>
+        <div className='btn-group btn-group-justified details-button-group'>
           <div className='btn btn-default' onClick={this.newAttempt}>
             New attempt
           </div>
@@ -283,7 +284,7 @@ class _RunSession extends Component {
             {strAttemptEnabled}
           </div>
         </div>
-        <div className='btn-group-lg btn-group-justified details-button-group'>
+        <div className='btn-group btn-group-justified details-button-group'>
           <div className='btn btn-default' onClick={()=>{this.toggleStats(q._id)}}>
             {strStatsVisible}
           </div>
@@ -291,7 +292,7 @@ class _RunSession extends Component {
             {strCorrectVisible}
           </div>
         </div>
-        <div className='btn-group-lg btn-group-justified details-button-group'>
+        <div className='btn-group btn-group-justified details-button-group'>
           <div className='btn btn-default' onClick={this.prevQuestion}>
             <span className='glyphicon glyphicon-arrow-left' /> &nbsp;  Previous
           </div>
@@ -311,7 +312,7 @@ class _RunSession extends Component {
           ? <div><ShortAnswerList question={q} /></div>
           : ''
         }
-        <div className='btn-group btn-group-justified details-button-group'>
+        <div className='btn-group-lg btn-group-justified details-button-group'>
           <div className='btn btn-default' onClick={this.endSession}>
             <span className='glyphicon glyphicon-stop' />&nbsp;
             Finish Session
@@ -396,9 +397,9 @@ class _RunSession extends Component {
             <a href='#' className='toolbar-button' onClick={() => this.toggleCorrect(q._id)}>{strCorrectVisible}</a>
             <a href='#' className='toolbar-button' onClick={() => this.toggleStats(q._id)}>{strStatsVisible}</a>
             <span className='divider'>&nbsp;</span>
-            <span className='attempt-message'>Attempt ({currentAttempt.number})</span>
             <a href='#' className='toolbar-button' onClick={() => this.toggleAttempt(q._id)}>{strAttemptEnabled}</a>
             <a href='#' className='toolbar-button' onClick={this.newAttempt}>New Attempt</a>
+            <span className='attempt-message'>Attempt ({currentAttempt.number})</span>
             <span className='divider'>&nbsp;</span>
           </div>
 

--- a/imports/ui/pages/professor/run_session.jsx
+++ b/imports/ui/pages/professor/run_session.jsx
@@ -227,8 +227,82 @@ class _RunSession extends Component {
       })
     }
   }
+  renderMobile(){
+
+    if (this.state.session.status !== 'running') return <div className='ql-subs-loading'>Session not running</div>
+    const current = this.state.session.currentQuestion
+    if (this.props.loading || !current) return <div className='ql-subs-loading'>Loading</div>
+
+    let questionList = this.state.session.questions || []
+
+    const q = this.props.questions[current]
+    if (!q.sessionOptions) return <div>Loading</div>
+    const currentAttempt = q.sessionOptions.attempts[q.sessionOptions.attempts.length - 1]
+
+    // strings
+    const strQuestionVisible = q.sessionOptions.hidden ? 'Show Question' : 'Hide Question'
+    const strCorrectVisible = q.sessionOptions.correct ? 'Hide Correct' : 'Show Correct'
+    const strStatsVisible = q.sessionOptions.stats ? 'Hide Stats' : 'Show Stats'
+    const strAttemptEnabled = currentAttempt.closed ? 'Allow Responses' : 'Disallow Responses'
+
+    const numAnswered = this.props.responses.length
+    const numJoined = this.props.session.joined ? this.props.session.joined.length : 0
+
+    return (
+      <div className='ql-manage-session'>
+
+        <div className='ql-session-toolbar'>
+          <h3 className='session-title'>{ this.state.session.name }</h3>
+          <span className='divider'>&nbsp;</span>
+          <span className='divider'>&nbsp;</span>
+          <span data-tip data-for='students' className='session-title'><span className='glyphicon glyphicon-user' />&nbsp;{ numJoined }</span>
+          <span className='divider'>&nbsp;</span>
+          <span className='toolbar-button' onClick={this.endSession}>
+            <span className='glyphicon glyphicon-stop' />&nbsp;
+            Finish Session
+          </span>
+          <span className='divider'>&nbsp;</span>
+          <a href='#' className='toolbar-button next' onClick={this.prevQuestion}><span className='glyphicon glyphicon-arrow-left' />&nbsp; Previous</a>
+          <a href='#' className='toolbar-button prev' onClick={this.nextQuestion}>Next &nbsp;<span className='glyphicon glyphicon-arrow-right' /></a>
+          <span className='divider'>&nbsp;</span>
+
+        </div>
+
+        <div className='ql-row-container'>
+          <div className='ql-question-toolbar'>
+            <h3 className='question-number'>Question {questionList.indexOf(current) + 1}/{questionList.length}</h3>
+            <span className='divider'>&nbsp;</span>
+            <div className='student-counts'><span className='glyphicon glyphicon-check' />&nbsp;{numAnswered}/{numJoined}</div>
+            <span className='divider'>&nbsp;</span>
+            <a href='#' className='toolbar-button' onClick={() => this.toggleHidden(q._id)}>{strQuestionVisible}</a>
+            <a href='#' className='toolbar-button' onClick={() => this.toggleCorrect(q._id)}>{strCorrectVisible}</a>
+            <a href='#' className='toolbar-button' onClick={() => this.toggleStats(q._id)}>{strStatsVisible}</a>
+            <span className='divider'>&nbsp;</span>
+            <span className='attempt-message'>Attempt ({currentAttempt.number})</span>
+            <a href='#' className='toolbar-button' onClick={() => this.toggleAttempt(q._id)}>{strAttemptEnabled}</a>
+            <a href='#' className='toolbar-button' onClick={this.newAttempt}>New Attempt</a>
+            <span className='divider'>&nbsp;</span>
+          </div>
+
+          <div className={'ql-main-content ' + (this.state.presenting ? 'presenting' : '')}>
+            {
+              !this.state.presenting && q && q.type === QUESTION_TYPE.SA // short answer
+              ? <div><ShortAnswerList question={q} /></div>
+              : ''
+            }
+
+            <div className='ql-question-preview'>
+              { q ? <QuestionDisplay question={q} attempt={currentAttempt} readonly prof /> : '' }
+            </div>
+          </div>
+
+        </div>
+      </div> )
+
+  }
 
   render () {
+    if (this.props.mobile) return this.renderMobile()
     if (this.state.session.status !== 'running') return <div className='ql-subs-loading'>Session not running</div>
     const current = this.state.session.currentQuestion
     if (this.props.loading || !current) return <div className='ql-subs-loading'>Loading</div>
@@ -349,7 +423,7 @@ class _RunSession extends Component {
           </div>
 
         </div>
-      </div>)
+      </div> )
   }
 
 }
@@ -379,4 +453,3 @@ export const RunSession = createContainer((props) => {
     loading: !handle.ready()
   }
 }, _RunSession)
-

--- a/imports/ui/pages/professor/run_session.jsx
+++ b/imports/ui/pages/professor/run_session.jsx
@@ -260,7 +260,7 @@ class _RunSession extends Component {
     const strQuestionVisible = q.sessionOptions.hidden ? 'Show Question' : 'Hide Question'
     const strCorrectVisible = q.sessionOptions.correct ? 'Hide Correct' : 'Show Correct'
     const strStatsVisible = q.sessionOptions.stats ? 'Hide Stats' : 'Show Stats'
-    const strAttemptEnabled = currentAttempt.closed ? 'Allow Responses' : 'Disallow Responses'
+    const strAttemptEnabled = currentAttempt.closed ? 'Allow responses' : 'Disallow responses'
 
     const numAnswered = this.props.responses.length
     const numJoined = this.props.session.joined ? this.props.session.joined.length : 0
@@ -275,18 +275,23 @@ class _RunSession extends Component {
         Question: {questionList.indexOf(current) + 1}/{questionList.length}&nbsp;&nbsp;
         Responses: <span className='glyphicon glyphicon-check' />&nbsp;{numAnswered}/{numJoined}&nbsp;&nbsp;
         Attempt: {q.sessionOptions.attempts.length}
-        <div className='btn-group btn-group-justified details-button-group'>
+        <div className='btn-group-lg btn-group-justified details-button-group'>
+          <div className='btn btn-default' onClick={this.newAttempt}>
+            New attempt
+          </div>
+          <div className='btn btn-default' onClick={() => this.toggleAttempt(q._id)}>
+            {strAttemptEnabled}
+          </div>
+        </div>
+        <div className='btn-group-lg btn-group-justified details-button-group'>
           <div className='btn btn-default' onClick={()=>{this.toggleStats(q._id)}}>
             {strStatsVisible}
           </div>
           <div className='btn btn-default' onClick={()=>{this.toggleCorrect(q._id)}}>
             {strCorrectVisible}
           </div>
-          <div className='btn btn-default' onClick={this.newAttempt}>
-            New attempt
-          </div>
         </div>
-        <div className='btn-group btn-group-justified details-button-group'>
+        <div className='btn-group-lg btn-group-justified details-button-group'>
           <div className='btn btn-default' onClick={this.prevQuestion}>
             <span className='glyphicon glyphicon-arrow-left' /> &nbsp;  Previous
           </div>
@@ -301,7 +306,11 @@ class _RunSession extends Component {
         <div className='ql-question-preview'>
           { q ? <QuestionDisplay question={q} attempt={currentAttempt} readonly prof showStatsOverride /> : '' }
         </div>
-
+        {
+          !this.state.presenting && q && q.type === QUESTION_TYPE.SA // short answer
+          ? <div><ShortAnswerList question={q} /></div>
+          : ''
+        }
         <div className='btn-group btn-group-justified details-button-group'>
           <div className='btn btn-default' onClick={this.endSession}>
             <span className='glyphicon glyphicon-stop' />&nbsp;
@@ -339,7 +348,6 @@ class _RunSession extends Component {
     const togglePresenting = () => { this.setState({ presenting: !this.state.presenting }) }
     return (
       <div className='ql-manage-session'>
-
         <div className='ql-session-toolbar'>
           <h3 className='session-title'>{ this.state.session.name }</h3>
           <span className='divider'>&nbsp;</span>
@@ -373,11 +381,6 @@ class _RunSession extends Component {
             <span className='glyphicon glyphicon-phone' />&nbsp;
             Mobile view
           </a>
-          <span className='divider'>&nbsp;</span>
-          <a href='#' className='toolbar-button next' onClick={this.prevQuestion}><span className='glyphicon glyphicon-arrow-left' />&nbsp; Previous</a>
-          <a href='#' className='toolbar-button prev' onClick={this.nextQuestion}>Next &nbsp;<span className='glyphicon glyphicon-arrow-right' /></a>
-          <span className='divider'>&nbsp;</span>
-
         </div>
 
         <div className='ql-row-container'>
@@ -385,6 +388,9 @@ class _RunSession extends Component {
             <h3 className='question-number'>Question {questionList.indexOf(current) + 1}/{questionList.length}</h3>
             <span className='divider'>&nbsp;</span>
             <div className='student-counts'><span className='glyphicon glyphicon-check' />&nbsp;{numAnswered}/{numJoined}</div>
+            <span className='divider'>&nbsp;</span>
+            <a href='#' className='toolbar-button next' onClick={this.prevQuestion}><span className='glyphicon glyphicon-arrow-left' />&nbsp; Previous</a>
+            <a href='#' className='toolbar-button prev' onClick={this.nextQuestion}>Next &nbsp;<span className='glyphicon glyphicon-arrow-right' /></a>
             <span className='divider'>&nbsp;</span>
             <a href='#' className='toolbar-button' onClick={() => this.toggleHidden(q._id)}>{strQuestionVisible}</a>
             <a href='#' className='toolbar-button' onClick={() => this.toggleCorrect(q._id)}>{strCorrectVisible}</a>

--- a/imports/ui/pages/professor/run_session.jsx
+++ b/imports/ui/pages/professor/run_session.jsx
@@ -40,6 +40,8 @@ class _RunSession extends Component {
     this.toggleHidden = this.toggleHidden.bind(this)
     this.toggleCorrect = this.toggleCorrect.bind(this)
     this.toggleAttempt = this.toggleAttempt.bind(this)
+    this.routeMobile = this.routeMobile.bind(this)
+    this.routeDesktop = this.routeDesktop.bind(this)
 
     Meteor.call('questions.startAttempt', this.state.session.currentQuestion)
   }
@@ -55,6 +57,21 @@ class _RunSession extends Component {
     })
   }
 
+  /**
+   * routeMobile
+   * Routes to the mobile version
+   */
+  routeMobile() {
+    Router.go('session.run.mobile',{_id:this.props.session._id})
+  }
+
+  /**
+   * routeDesktop
+   * Routes to the desktop version
+   */
+  routeDesktop() {
+    Router.go('session.run',{_id:this.props.session._id})
+  }
   /**
    * toggleStats(MongoId (string): questionId)
    * calls questions.showStats or .hideStats to show/hide answer distribution from students
@@ -249,56 +266,49 @@ class _RunSession extends Component {
     const numJoined = this.props.session.joined ? this.props.session.joined.length : 0
 
     return (
-      <div className='ql-manage-session'>
+      <div className='container ql-session-display'>
+        <a className='toolbar-button' href='#' onClick={this.routeDesktop}>
+          <span className='glyphicon glyphicon-fullscreen' />&nbsp;
+          Desktop view
+        </a>&nbsp;&nbsp;&nbsp;&nbsp;
+        <span className='glyphicon glyphicon-user' />&nbsp;{ numJoined }&nbsp;&nbsp;
+        Question: {questionList.indexOf(current) + 1}/{questionList.length}&nbsp;&nbsp;
+        Responses: <span className='glyphicon glyphicon-check' />&nbsp;{numAnswered}/{numJoined}&nbsp;&nbsp;
+        Attempt: {q.sessionOptions.attempts.length}
+        <div className='btn-group btn-group-justified details-button-group'>
+          <div className='btn btn-default' onClick={()=>{this.toggleStats(q._id)}}>
+            {strStatsVisible}
+          </div>
+          <div className='btn btn-default' onClick={()=>{this.toggleCorrect(q._id)}}>
+            {strCorrectVisible}
+          </div>
+          <div className='btn btn-default' onClick={this.newAttempt}>
+            New attempt
+          </div>
+        </div>
+        <div className='btn-group btn-group-justified details-button-group'>
+          <div className='btn btn-default' onClick={this.prevQuestion}>
+            <span className='glyphicon glyphicon-arrow-left' /> &nbsp;  Previous
+          </div>
+          <div className='btn btn-default' onClick={() => this.toggleHidden(q._id)}>
+            {strQuestionVisible}
+          </div>
+          <div className='btn btn-default' onClick={this.nextQuestion}>
+            Next &nbsp;<span className='glyphicon glyphicon-arrow-right' />
+          </div>
+        </div>
 
-        <div className='ql-session-toolbar'>
-          <h3 className='session-title'>{ this.state.session.name }</h3>
-          <span className='divider'>&nbsp;</span>
-          <span className='divider'>&nbsp;</span>
-          <span data-tip data-for='students' className='session-title'><span className='glyphicon glyphicon-user' />&nbsp;{ numJoined }</span>
-          <span className='divider'>&nbsp;</span>
-          <span className='toolbar-button' onClick={this.endSession}>
+        <div className='ql-question-preview'>
+          { q ? <QuestionDisplay question={q} attempt={currentAttempt} readonly prof showStatsOverride /> : '' }
+        </div>
+
+        <div className='btn-group btn-group-justified details-button-group'>
+          <div className='btn btn-default' onClick={this.endSession}>
             <span className='glyphicon glyphicon-stop' />&nbsp;
             Finish Session
-          </span>
-          <span className='divider'>&nbsp;</span>
-          <a href='#' className='toolbar-button next' onClick={this.prevQuestion}><span className='glyphicon glyphicon-arrow-left' />&nbsp; Previous</a>
-          <a href='#' className='toolbar-button prev' onClick={this.nextQuestion}>Next &nbsp;<span className='glyphicon glyphicon-arrow-right' /></a>
-          <span className='divider'>&nbsp;</span>
-
-        </div>
-
-        <div className='ql-row-container'>
-          <div className='ql-question-toolbar'>
-            <h3 className='question-number'>Question {questionList.indexOf(current) + 1}/{questionList.length}</h3>
-            <span className='divider'>&nbsp;</span>
-            <div className='student-counts'><span className='glyphicon glyphicon-check' />&nbsp;{numAnswered}/{numJoined}</div>
-            <span className='divider'>&nbsp;</span>
-            <a href='#' className='toolbar-button' onClick={() => this.toggleHidden(q._id)}>{strQuestionVisible}</a>
-            <a href='#' className='toolbar-button' onClick={() => this.toggleCorrect(q._id)}>{strCorrectVisible}</a>
-            <a href='#' className='toolbar-button' onClick={() => this.toggleStats(q._id)}>{strStatsVisible}</a>
-            <span className='divider'>&nbsp;</span>
-            <span className='attempt-message'>Attempt ({currentAttempt.number})</span>
-            <a href='#' className='toolbar-button' onClick={() => this.toggleAttempt(q._id)}>{strAttemptEnabled}</a>
-            <a href='#' className='toolbar-button' onClick={this.newAttempt}>New Attempt</a>
-            <span className='divider'>&nbsp;</span>
           </div>
-
-          <div className={'ql-main-content ' + (this.state.presenting ? 'presenting' : '')}>
-            {
-              !this.state.presenting && q && q.type === QUESTION_TYPE.SA // short answer
-              ? <div><ShortAnswerList question={q} /></div>
-              : ''
-            }
-
-            <div className='ql-question-preview'>
-              { q ? <QuestionDisplay question={q} attempt={currentAttempt} readonly prof /> : '' }
-            </div>
-          </div>
-
         </div>
-      </div> )
-
+      </div>)
   }
 
   render () {
@@ -359,6 +369,10 @@ class _RunSession extends Component {
             <span className='glyphicon glyphicon-blackboard' />&nbsp;
             2nd Display
           </span>
+          <a className='toolbar-button' href='#' onClick={this.routeMobile}>
+            <span className='glyphicon glyphicon-phone' />&nbsp;
+            Mobile view
+          </a>
           <span className='divider'>&nbsp;</span>
           <a href='#' className='toolbar-button next' onClick={this.prevQuestion}><span className='glyphicon glyphicon-arrow-left' />&nbsp; Previous</a>
           <a href='#' className='toolbar-button prev' onClick={this.nextQuestion}>Next &nbsp;<span className='glyphicon glyphicon-arrow-right' /></a>

--- a/imports/ui/pages/student/session.jsx
+++ b/imports/ui/pages/student/session.jsx
@@ -34,7 +34,13 @@ class _Session extends Component {
       if (status === 'visible') statusMessage = 'This session has not started yet. You can keep this page open until your professor starts the session or check back soon.'
       if (status === 'done'){
         statusMessage = 'This session has finished'
-        Router.go("/course/"+this.props.session.courseId)
+        user = Meteor.user()
+        cId = this.props.session.courseId
+        if(user && !user.isInstructor(cId)){
+          //if it's an instructor, this is being shown as a second display, so dont't
+          //go to the course page and show everyone the class list
+          Router.go("/course/"+this.props.session.courseId)
+        }
       }
       return <div className='ql-subs-loading'>{statusMessage}</div>
     }
@@ -68,4 +74,3 @@ export const Session = createContainer((props) => {
     loading: !handle.ready()
   }
 }, _Session)
-


### PR DESCRIPTION
- Approving a student question using the dropdown menu takes over ownership
- 2nd display of session run goes blank when session finishes (instead of showing course page)
- classlist header toggles expanded view (needs CSS to show it's clickable...)
- duplicate session does not copy sessionOptions for question
- fixed questionDisplay to check for sessionOptions defined everywhere
- Added a mobile view to run a session (as a route)
- Moved things around in session run, as there are some issues with the toolbar buttons wrapping as the viewport changes (it's particularly awkward on my samsung S6) - Still needs fixing!
- Added percentage values in display when showing stats
- Render the math for SA answers (in prof and forReview modes)
- Used bootstrap to expand QuestionDisplay in student review mode