### PR TITLE
removed field restriction on response pub

### DIFF
--- a/imports/api/responses.js
+++ b/imports/api/responses.js
@@ -54,7 +54,8 @@ if (Meteor.isServer) {
         const findCriteria = { questionId: questionId }
         // Prevent students from seeing the studentIds of other students when
         // recieving responses.
-        return Responses.find(findCriteria, { fields: { 'studentUserId': false } })
+        //return Responses.find(findCriteria, { fields: { 'studentUserId': false } })
+        return Responses.find(findCriteria)
       }
     } else this.ready()
   })


### PR DESCRIPTION
Had to remove the restriction, as QuestionDisplay needs to know if one of the responses belongs to the current user. We'll have to be a lot more careful how we implement the restriction on the response publication.