### PR TITLE
Remove settings.json

### DIFF
--- a/client/css/components/LoginBox.scss
+++ b/client/css/components/LoginBox.scss
@@ -45,6 +45,7 @@
   -webkit-box-shadow: 0px 0px 7px 0px rgba(0,0,0,0.1);
   -moz-box-shadow: 0px 0px 7px 0px rgba(0,0,0,0.1);
   box-shadow: 0px 0px 7px 0px rgba(0,0,0,0.1);
+  width: 100%;
 
   .header-container {
 

--- a/client/css/components/admin_dashboard.scss
+++ b/client/css/components/admin_dashboard.scss
@@ -11,9 +11,7 @@
     justify-content: space-between;
 }
 
-.rd {
-   
-    
-}
+
+
 
 

--- a/client/css/components/admin_dashboard.scss
+++ b/client/css/components/admin_dashboard.scss
@@ -1,0 +1,19 @@
+@import '../bootstrap-style.scss';
+
+.ql-admin-page {
+    display: flex;
+    flex-direction: column;
+}
+
+.ql-admin-settings {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
+.rd {
+   
+    
+}
+
+

--- a/imports/api/images.js
+++ b/imports/api/images.js
@@ -12,8 +12,6 @@ import Helpers from './helpers.js'
 
 import { _ } from 'underscore'
 
-import { Slingshot } from 'meteor/edgee:slingshot'
-
 // expected collection pattern
 const imagePattern = {
   _id: Match.Maybe(Helpers.MongoID),

--- a/imports/api/images.js
+++ b/imports/api/images.js
@@ -12,6 +12,8 @@ import Helpers from './helpers.js'
 
 import { _ } from 'underscore'
 
+import { Slingshot } from 'meteor/edgee:slingshot'
+
 // expected collection pattern
 const imagePattern = {
   _id: Match.Maybe(Helpers.MongoID),
@@ -115,6 +117,22 @@ Meteor.methods({
         }
       })
     }))
+  },
+  /**
+   * Updates the AWS credentials set by admin
+   */
+  'updateCredentials' (bucket, region, AWSAccessKeyId, AWSSecretAccessKey) {
+    if (!Meteor.user().hasRole('admin')) throw new Error('Not authorized')
+
+    if (Meteor.isServer) {
+      directive = Slingshot.getDirective('QuestionImages')
+      if(directive === undefined) throw new Error('No Directive')
+      directive._directive.bucket = bucket
+      directive._directive.region = region
+      directive._directive.AWSAccessKeyId = AWSAccessKeyId
+      directive._directive.AWSSecretAccessKey = AWSSecretAccessKey
+      return directive
+    }
   }
 
 }) // end Meteor.methods

--- a/imports/api/images.js
+++ b/imports/api/images.js
@@ -117,22 +117,6 @@ Meteor.methods({
         }
       })
     }))
-  },
-  /**
-   * Updates the AWS credentials set by admin
-   */
-  'updateCredentials' (bucket, region, AWSAccessKeyId, AWSSecretAccessKey) {
-    if (!Meteor.user().hasRole('admin')) throw new Error('Not authorized')
-
-    if (Meteor.isServer) {
-      directive = Slingshot.getDirective('QuestionImages')
-      if(directive === undefined) throw new Error('No Directive')
-      directive._directive.bucket = bucket
-      directive._directive.region = region
-      directive._directive.AWSAccessKeyId = AWSAccessKeyId
-      directive._directive.AWSSecretAccessKey = AWSSecretAccessKey
-      return directive
-    }
   }
 
 }) // end Meteor.methods

--- a/imports/api/settings.js
+++ b/imports/api/settings.js
@@ -5,7 +5,7 @@
 
 import { Meteor } from 'meteor/meteor'
 import { Mongo } from 'meteor/mongo'
-import { check } from 'meteor/check'
+import { check, Match } from 'meteor/check'
 
 import { _ } from 'underscore'
 
@@ -20,7 +20,11 @@ const pattern = {
   maxImageSize: Number,
   maxImageWidth: Number,
   email: String,
-  requireVerified: Boolean
+  requireVerified: Boolean,
+  bucket: Match.Maybe(String),
+  region: Match.Maybe(String),
+  accessKey: Match.Maybe(String),
+  secret: Match.Maybe(String)
 }
 
 // Create course class
@@ -88,6 +92,14 @@ Meteor.methods({
       if (user.hasRole(ROLES.admin)) {
         if (settings.email && settings.email !== Settings.findOne().email && Meteor.isServer) {
           Accounts.emailTemplates.from = 'Qlicker Admin <' + settings.email + '>'
+        }
+        if (Meteor.isServer && settings.bucket) {
+          directive = Slingshot.getDirective('QuestionImages')._directive
+          if(directive === undefined) throw new Error('No Directive')
+          directive.bucket = settings.bucket
+          directive.region = settings.region
+          directive.AWSAccessKeyId = settings.accessKey
+          directive.AWSSecretAccessKey = settings.secret
         }
         return Settings.update(settings._id, settings)
       }

--- a/imports/api/settings.js
+++ b/imports/api/settings.js
@@ -24,7 +24,12 @@ const pattern = {
   bucket: Match.Maybe(String),
   region: Match.Maybe(String),
   accessKey: Match.Maybe(String),
-  secret: Match.Maybe(String)
+  secret: Match.Maybe(String),
+  AWS_bucket: Match.Maybe(String),
+  AWS_region: Match.Maybe(String),
+  AWS_accessKey: Match.Maybe(String),
+  AWS_secret: Match.Maybe(String),
+  AWS_: Match.Maybe(String)
 }
 
 // Create course class
@@ -93,14 +98,15 @@ Meteor.methods({
         if (settings.email && settings.email !== Settings.findOne().email && Meteor.isServer) {
           Accounts.emailTemplates.from = 'Qlicker Admin <' + settings.email + '>'
         }
-        if (Meteor.isServer && settings.bucket) {
+        if (Meteor.isServer && settings.AWS_bucket) {
           directive = Slingshot.getDirective('QuestionImages')._directive
           if(directive === undefined) throw new Error('No Directive')
-          directive.bucket = settings.bucket
-          directive.region = settings.region
-          directive.AWSAccessKeyId = settings.accessKey
-          directive.AWSSecretAccessKey = settings.secret
+          directive.bucket = settings.AWS_bucket
+          directive.region = settings.AWS_region
+          directive.AWSAccessKeyId = settings.AWS_accessKey
+          directive.AWSSecretAccessKey = settings.AWS_secret
         }
+        settings = _.omit(settings, 'AWS_')
         return Settings.update(settings._id, settings)
       }
     }

--- a/imports/ui/pages/admin/admin_dashboard.jsx
+++ b/imports/ui/pages/admin/admin_dashboard.jsx
@@ -10,6 +10,10 @@ import { RestrictDomainForm } from '../../RestrictDomainForm'
 
 import { Settings } from '../../../api/settings'
 
+import { Images } from '../../../api/images'
+
+import { Slingshot } from 'meteor/edgee:slingshot'
+
 import { Courses } from '../../../api/courses'
 
 import { ROLES } from '../../../configs'
@@ -72,6 +76,30 @@ class _AdminDashboard extends Component {
     Meteor.call('settings.update', settings, (e, d) => {
       if (e) alertify.error('Error updating settings')
       else alertify.success('Settings updated')
+    })
+  }
+
+  saveBucket (e) {
+    e.preventDefault
+    let settings = Settings.findOne()
+    settings.bucket = this.state.bucket
+    settings.AWSAccessKeyId = this.state.accessKey
+    settings.AWSSecretAccessKey = this.state.secret
+    settings.region = this.state.region
+   
+    Meteor.call('settings.update', settings, (e, d) => {
+      if (e) alertify.error('Error updating settings')
+      else alertify.success('Settings updated')
+      //   Slingshot.createDirective('QuestionImages', Slingshot.S3Storage, {
+      //   allowedFileTypes: ['image/png', 'image/jpeg', 'image/jpg', 'image/gif'],
+      //   maxSize: null, // Unlimited, handled in authorized() instead
+      //   bucket: settings.bucket,
+      //   region: settings.region,
+      //   AWSAccessKeyId: settings.accessKey,
+      //   AWSSecretAccessKey: settings.secret,
+      //   acl: 'public-read',
+      // })
+
     })
   }
 

--- a/imports/ui/pages/admin/admin_dashboard.jsx
+++ b/imports/ui/pages/admin/admin_dashboard.jsx
@@ -30,7 +30,11 @@ class _AdminDashboard extends Component {
       size: p.settings.maxImageSize,
       width: p.settings.maxImageWidth,
       supportEmail: p.settings.email,
-      requireVerified: p.settings.requireVerified
+      requireVerified: p.settings.requireVerified,
+      bucket: '',
+      region: '',
+      accessKey: '',
+      secret: ''      
     }
 
     this.saveRoleChange = this.saveRoleChange.bind(this)
@@ -142,7 +146,11 @@ class _AdminDashboard extends Component {
     const setImageSize = (e) => { this.setState({ size: e.target.value }) }
     const setImageWidth = (e) => { this.setState({ width: e.target.value }) }
     const setSupportEmail = (e) => { this.setState({ supportEmail: e.target.value }) }
-
+    const setBucket = (e) => { this.setState({ bucket: e.target.value }) }
+    const setRegion = (e) => { this.setState({ region: e.target.value }) }
+    const setAccessKey = (e) => { this.setState({ accessKey: e.target.value }) }
+    const setSecret = (e) => { this.setState({ secret: e.target.value }) }
+    
     return (
       <div className='container ql-admin-page'>
         <h2>Admin User Management</h2>
@@ -168,6 +176,30 @@ class _AdminDashboard extends Component {
 
         <h4>Require verified email to login</h4>
         <input type='checkbox' checked={this.state.requireVerified} onChange={this.setVerified} />
+
+        <h4>AWS Bucket Name</h4>
+        <form ref='supportForm' onSubmit={this.saveBucket} className='form-inline'>
+          <input className='form-control' value={this.state.bucket} type='text' onChange={setBucket} />
+          <input type='submit' className='btn btn-primary' value='Set' />
+        </form>
+
+        <h4>AWS Bucket Region</h4>
+        <form ref='supportForm' onSubmit={this.saveEmail} className='form-inline'>
+          <input className='form-control' value={this.state.region} type='text' onChange={setRegion} />
+          <input type='submit' className='btn btn-primary' value='Set' />
+        </form>
+
+        <h4>AWS Access Key Id</h4>
+        <form ref='supportForm' onSubmit={this.saveEmail} className='form-inline'>
+          <input className='form-control' value={this.state.accessKey} type='text' onChange={setAccessKey} />
+          <input type='submit' className='btn btn-primary' value='Set' />
+        </form>
+
+        <h4>AWS Secret</h4>
+        <form ref='supportForm' onSubmit={this.saveEmail} className='form-inline'>
+          <input className='form-control' value={this.state.secret} type='text' onChange={setSecret} />
+          <input type='submit' className='btn btn-primary' value='Set' />
+        </form>
 
         <RestrictDomainForm
           done={() => { return true }}

--- a/imports/ui/pages/admin/admin_dashboard.jsx
+++ b/imports/ui/pages/admin/admin_dashboard.jsx
@@ -10,10 +10,6 @@ import { RestrictDomainForm } from '../../RestrictDomainForm'
 
 import { Settings } from '../../../api/settings'
 
-import { Images } from '../../../api/images'
-
-import { Slingshot } from 'meteor/edgee:slingshot'
-
 import { Courses } from '../../../api/courses'
 
 import { ROLES } from '../../../configs'
@@ -80,30 +76,6 @@ class _AdminDashboard extends Component {
     Meteor.call('settings.update', settings, (e, d) => {
       if (e) alertify.error('Error updating settings')
       else alertify.success('Settings updated')
-    })
-  }
-
-  saveBucket (e) {
-    e.preventDefault
-    let settings = Settings.findOne()
-    settings.bucket = this.state.bucket
-    settings.AWSAccessKeyId = this.state.accessKey
-    settings.AWSSecretAccessKey = this.state.secret
-    settings.region = this.state.region
-   
-    Meteor.call('settings.update', settings, (e, d) => {
-      if (e) alertify.error('Error updating settings')
-      else alertify.success('Settings updated')
-      //   Slingshot.createDirective('QuestionImages', Slingshot.S3Storage, {
-      //   allowedFileTypes: ['image/png', 'image/jpeg', 'image/jpg', 'image/gif'],
-      //   maxSize: null, // Unlimited, handled in authorized() instead
-      //   bucket: settings.bucket,
-      //   region: settings.region,
-      //   AWSAccessKeyId: settings.accessKey,
-      //   AWSSecretAccessKey: settings.secret,
-      //   acl: 'public-read',
-      // })
-
     })
   }
 

--- a/imports/ui/pages/admin/admin_dashboard.jsx
+++ b/imports/ui/pages/admin/admin_dashboard.jsx
@@ -29,10 +29,10 @@ class _AdminDashboard extends Component {
       width: p.settings.maxImageWidth,
       supportEmail: p.settings.email,
       requireVerified: p.settings.requireVerified,
-      bucket: '',
-      region: '',
-      accessKey: '',
-      secret: ''      
+      bucket:  p.settings.bucket,
+      region: p.settings.region,
+      accessKey: p.settings.accessKey,
+      secret: p.settings.secret
     }
 
     this.saveRoleChange = this.saveRoleChange.bind(this)
@@ -64,6 +64,7 @@ class _AdminDashboard extends Component {
     e.preventDefault()
 
     let settings = Settings.findOne()
+    console.log(settings.bucket)
     settings.maxImageSize = !isNaN(Number(this.state.size)) ? Number(this.state.size) : 0
     Meteor.call('settings.update', settings, (e, d) => {
       if (e) alertify.error('Error updating settings')
@@ -85,15 +86,17 @@ class _AdminDashboard extends Component {
   saveCredentials (e) {
     e.preventDefault
 
-    Meteor.call('updateCredentials', this.state.bucket, this.state.region, this.state.accessKey, this.state.secret, (err, result) => {
-      if (err) {
-        alertify.error('Error')
-      }
-      else {
-        console.log(result)
-        alertify.success('Updated')
-      }
+    let settings = Settings.findOne()
+    settings.bucket = this.state.bucket
+    settings.region = this.state.region
+    settings.accessKey = this.state.accessKey
+    settings.secret = this.state.secret
+
+    Meteor.call('settings.update', settings, (e, d) => {
+      if (e) alertify.error('Error updating settings')
+      else alertify.success('Settings updated')
     })
+    
   }
   verifyUserEmail (email) {
     Meteor.call('users.verifyEmail', email, (e, d) => {
@@ -171,14 +174,14 @@ class _AdminDashboard extends Component {
               
                 
             <form className='ql-admin-login-box col-md-4' onSubmit={this.saveCredentials}>
-              <h4>Change AWS Credentials</h4> 
+              <h4>Image Storage Settings</h4> 
               <div className='ql-card-content inputs-container'>
                 <input className='form-control' type='text' value={this.state.bucket} onChange={setBucket} placeholder='Bucket Name' /><br />
                 <input className='form-control' type='text' value={this.state.region} onChange={setRegion} placeholder='Region' /><br />
                 <input className='form-control' type='text' value={this.state.accessKey} onChange={setAccessKey} placeholder='AWS Access Key Id' /><br />
                 <input className='form-control' type='text' value={this.state.secret} onChange={setSecret} placeholder='AWS Secret' /><br />
                 <div className='spacer1'>&nbsp;</div>
-                <input type='submit' id='submitButton' className='btn btn-primary btn-block' value='Submit' />
+                <input type='submit' id='submitStorage' className='btn btn-primary btn-block' value='Submit' />
               </div>
             </form>        
           </div>

--- a/imports/ui/pages/admin/admin_dashboard.jsx
+++ b/imports/ui/pages/admin/admin_dashboard.jsx
@@ -152,11 +152,11 @@ class _AdminDashboard extends Component {
           </form>
         </div>
         
-
-        <h2>Image Settings</h2>
-        <br />
         <div className='ql-admin-settings'>
-          <div> 
+          <div>
+            <h2>Image Settings</h2>
+            <br />      
+        
             <h4>Maximum image size (in MB, after rescaling to max width)</h4>
             <form ref='imageSizeForm' onSubmit={this.saveImageSize} className='form-inline'>
               <input className='form-control' value={this.state.size} type='text' onChange={setImageSize} placeholder='Image size' />
@@ -168,51 +168,51 @@ class _AdminDashboard extends Component {
               <input className='form-control' value={this.state.width} type='text' onChange={setImageWidth} placeholder='Image width' />
               <input type='submit' className='btn btn-primary' value='Set' />
             </form>
-          </div>   
-            
-          <form className='ql-admin-login-box col-md-4' onSubmit={this.saveCredentials}>
-            <h4>Change AWS Credentials</h4> 
-            <div className='ql-card-content inputs-container'>
-              <div className='input-group'>
-                <input className='form-control' type='text' value={this.state.bucket} onChange={setBucket} placeholder='Bucket Name' />
-                <input className='form-control' type='text' value={this.state.region} onChange={setRegion} placeholder='Region' />
-              </div>         
-              <input className='form-control' type='text' value={this.state.accessKey} onChange={setAccessKey} placeholder='AWS Access Key Id' /><br />
-              <input className='form-control' type='text' value={this.state.secret} onChange={setSecret} placeholder='AWS Secret' /><br />
-              <div className='spacer1'>&nbsp;</div>
-              <input type='submit' id='submitButton' className='btn btn-primary btn-block' value='Submit' />
-            </div>
-          </form>        
-        </div>
+              
+                
+            <form className='ql-admin-login-box col-md-4' onSubmit={this.saveCredentials}>
+              <h4>Change AWS Credentials</h4> 
+              <div className='ql-card-content inputs-container'>
+                <input className='form-control' type='text' value={this.state.bucket} onChange={setBucket} placeholder='Bucket Name' /><br />
+                <input className='form-control' type='text' value={this.state.region} onChange={setRegion} placeholder='Region' /><br />
+                <input className='form-control' type='text' value={this.state.accessKey} onChange={setAccessKey} placeholder='AWS Access Key Id' /><br />
+                <input className='form-control' type='text' value={this.state.secret} onChange={setSecret} placeholder='AWS Secret' /><br />
+                <div className='spacer1'>&nbsp;</div>
+                <input type='submit' id='submitButton' className='btn btn-primary btn-block' value='Submit' />
+              </div>
+            </form>        
+          </div>
 
-        <h2>User Settings</h2>
-        <br />
-        <div className='ql-admin-settings'>
           <div>
+            <h2>User Settings</h2>
+            <br /> 
+            
             <h4>Require verified email to login</h4>
             <input type='checkbox' checked={this.state.requireVerified} onChange={this.setVerified} />
+            <br />
 
             <RestrictDomainForm
               done={() => { return true }}
               settings={this.props.settings}
             />
-          </div>
-          
-          <form className='ql-admin-login-box col-md-4' onSubmit={this.handleSubmit}>
-            <h4>Add user manually</h4>  
-            <div className='ql-card-content inputs-container'>
-              <div className='input-group'>
-                <input className='form-control' type='text' data-name='firstname' onChange={this.setValue} placeholder='First Name' />
-                <input className='form-control' type='text' data-name='lastname' onChange={this.setValue} placeholder='Last Name' />
+            <br />
+            
+            <form className='ql-admin-login-box col-md-4' onSubmit={this.handleSubmit}>
+              <h4>Add user manually</h4>  
+              <div className='ql-card-content inputs-container'>
+                <div className='input-group'>
+                  <input className='form-control' type='text' data-name='firstname' onChange={this.setValue} placeholder='First Name' />
+                  <input className='form-control' type='text' data-name='lastname' onChange={this.setValue} placeholder='Last Name' />
+                </div>
+                <input className='form-control' id='emailField' type='email' data-name='email' onChange={this.setValue} placeholder='Email' />
+                <br />
+                <input className='form-control' id='passwordField' type='password' data-name='password' onChange={this.setValue} placeholder='Password' /><br />
+                <div><input className='form-control' type='password' data-name='password_verify' onChange={this.setValue} placeholder='Retype Password' /><br /></div>
+                <div className='spacer1'>&nbsp;</div>
+                <input type='submit' id='submitButton' className='btn btn-primary btn-block' value='Submit' />
               </div>
-              <input className='form-control' id='emailField' type='email' data-name='email' onChange={this.setValue} placeholder='Email' />
-              <br />
-              <input className='form-control' id='passwordField' type='password' data-name='password' onChange={this.setValue} placeholder='Password' /><br />
-              <div><input className='form-control' type='password' data-name='password_verify' onChange={this.setValue} placeholder='Retype Password' /><br /></div>
-              <div className='spacer1'>&nbsp;</div>
-              <input type='submit' id='submitButton' className='btn btn-primary btn-block' value='Submit' />
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
 
         <div>

--- a/imports/ui/pages/admin/admin_dashboard.jsx
+++ b/imports/ui/pages/admin/admin_dashboard.jsx
@@ -141,122 +141,124 @@ class _AdminDashboard extends Component {
     
     return (
       <div className='container ql-admin-page'>
-        <h2>Admin User Management</h2>
+        <h1>Dashboard</h1>
         <br />
 
-        <h4>Maximum image size (in MB, after rescaling to max width)</h4>
-        <form ref='imageSizeForm' onSubmit={this.saveImageSize} className='form-inline'>
-          <input className='form-control' value={this.state.size} type='text' onChange={setImageSize} placeholder='Image size' />
-          <input type='submit' className='btn btn-primary' value='Set' />
-        </form>
+        <div>
+          <h4>Support email</h4>
+          <form ref='supportForm' onSubmit={this.saveEmail} className='form-inline'>
+            <input className='form-control' value={this.state.supportEmail} type='text' onChange={setSupportEmail} placeholder='Support email' />
+            <input type='submit' className='btn btn-primary' value='Set' />
+          </form>
+        </div>
+        
 
-        <h4>Maximum image width (px)</h4>
-        <form ref='imageWidthForm' onSubmit={this.saveImageWidth} className='form-inline'>
-          <input className='form-control' value={this.state.width} type='text' onChange={setImageWidth} placeholder='Image width' />
-          <input type='submit' className='btn btn-primary' value='Set' />
-        </form>
-
-        <h4>Support email</h4>
-        <form ref='supportForm' onSubmit={this.saveEmail} className='form-inline'>
-          <input className='form-control' value={this.state.supportEmail} type='text' onChange={setSupportEmail} placeholder='Support email' />
-          <input type='submit' className='btn btn-primary' value='Set' />
-        </form>
-
-        <h4>Require verified email to login</h4>
-        <input type='checkbox' checked={this.state.requireVerified} onChange={this.setVerified} />
-
-        <h4>AWS Bucket Name</h4>
-        <form ref='supportForm' onSubmit={this.saveEmail} className='form-inline'>
-          <input className='form-control' value={this.state.bucket} type='text' onChange={setBucket} />
-          <input type='submit' className='btn btn-primary' value='Set' />
-        </form>
-
-        <h4>AWS Bucket Region</h4>
-        <form ref='supportForm' onSubmit={this.saveEmail} className='form-inline'>
-          <input className='form-control' value={this.state.region} type='text' onChange={setRegion} />
-          <input type='submit' className='btn btn-primary' value='Set' />
-        </form>
-
-        <h4>AWS Access Key Id</h4>
-        <form ref='supportForm' onSubmit={this.saveEmail} className='form-inline'>
-          <input className='form-control' value={this.state.accessKey} type='text' onChange={setAccessKey} />
-          <input type='submit' className='btn btn-primary' value='Set' />
-        </form>
-
-        <h4>AWS Secret</h4>
-        <form ref='supportForm' onSubmit={this.saveEmail} className='form-inline'>
-          <input className='form-control' value={this.state.secret} type='text' onChange={setSecret} />
-          <input type='submit' className='btn btn-primary' value='Set' />
-        </form>
-
-        <input className='btn btn-primary' value='Set' onClick={this.saveCredentials} />
-
-        <RestrictDomainForm
-          done={() => { return true }}
-          settings={this.props.settings}
-        />
-
+        <h2>Image Settings</h2>
         <br />
-        <h4>Users (with elevated permissions first)</h4>
-        <table className='table table-bordered'>
-          <tbody>
-            <tr>
-              <th>Name</th>
-              <th>Email</th>
-              <th>Courses</th>
-              <th>Change Role</th>
-            </tr>
+        <div className='ql-admin-settings'>
+          <div> 
+            <h4>Maximum image size (in MB, after rescaling to max width)</h4>
+            <form ref='imageSizeForm' onSubmit={this.saveImageSize} className='form-inline'>
+              <input className='form-control' value={this.state.size} type='text' onChange={setImageSize} placeholder='Image size' />
+              <input type='submit' className='btn btn-primary' value='Set' />
+            </form>
 
-            {
-              this.props.allUsers.map((u) => {
-                let courseList = ''
-                if (u.profile.courses && this.props) {
-                  u.profile.courses.forEach(function (cId) {
-                    courseList += this.props.courseNames[cId] ? this.props.courseNames[cId] + ' ' : ''
-                  }.bind(this))
-                }
-                return (<tr key={u._id}>
-                  <td>
-                    <a href='#' onClick={(e) => this.toggleProfileViewModal(u)}>{u.getName()}</a>
-                  </td>
-                  <td>{u.getEmail()} &nbsp;&nbsp; {u.emails[0].verified ? '(verified)'
-                      : <a href='#' onClick={(e) => this.verifyUserEmail(u.getEmail())}>Verify</a>}
-                  </td>
-                  <td>{courseList}</td>
-                  <td>
-                    <select onChange={(e) => this.saveRoleChange(u._id, e.target.value)} value={u.getRole()}>
-                      { Object.keys(ROLES).map((r) => <option key={'role_' + ROLES[r]} value={ROLES[r]}>{ROLES[r]}</option>)}
-                    </select>
-                    &nbsp;&nbsp;{u.isInstructorAnyCourse() && u.hasRole('student') ? '(TA)' : ''}
-                  </td>
-                </tr>)
-              })
-            }
-          </tbody>
-        </table>
-
-        <h4>Add user manually</h4>
-        <form className='ql-admin-login-box col-md-4' onSubmit={this.handleSubmit}>
-          <div className='ql-card-content inputs-container'>
-            <div className='input-group'>
-              <input className='form-control' type='text' data-name='firstname' onChange={this.setValue} placeholder='First Name' />
-              <input className='form-control' type='text' data-name='lastname' onChange={this.setValue} placeholder='Last Name' />
+            <h4>Maximum image width (px)</h4>
+            <form ref='imageWidthForm' onSubmit={this.saveImageWidth} className='form-inline'>
+              <input className='form-control' value={this.state.width} type='text' onChange={setImageWidth} placeholder='Image width' />
+              <input type='submit' className='btn btn-primary' value='Set' />
+            </form>
+          </div>   
+            
+          <form className='ql-admin-login-box col-md-4' onSubmit={this.saveCredentials}>
+            <h4>Change AWS Credentials</h4> 
+            <div className='ql-card-content inputs-container'>
+              <div className='input-group'>
+                <input className='form-control' type='text' value={this.state.bucket} onChange={setBucket} placeholder='Bucket Name' />
+                <input className='form-control' type='text' value={this.state.region} onChange={setRegion} placeholder='Region' />
+              </div>         
+              <input className='form-control' type='text' value={this.state.accessKey} onChange={setAccessKey} placeholder='AWS Access Key Id' /><br />
+              <input className='form-control' type='text' value={this.state.secret} onChange={setSecret} placeholder='AWS Secret' /><br />
+              <div className='spacer1'>&nbsp;</div>
+              <input type='submit' id='submitButton' className='btn btn-primary btn-block' value='Submit' />
             </div>
+          </form>        
+        </div>
 
-            <input className='form-control' id='emailField' type='email' data-name='email' onChange={this.setValue} placeholder='Email' /><br />
+        <h2>User Settings</h2>
+        <br />
+        <div className='ql-admin-settings'>
+          <div>
+            <h4>Require verified email to login</h4>
+            <input type='checkbox' checked={this.state.requireVerified} onChange={this.setVerified} />
 
-            <input className='form-control' id='passwordField' type='password' data-name='password' onChange={this.setValue} placeholder='Password' /><br />
-            <div><input className='form-control' type='password' data-name='password_verify' onChange={this.setValue} placeholder='Retype Password' /><br /></div>
-
-            <div className='spacer1'>&nbsp;</div>
-            <input type='submit' id='submitButton' className='btn btn-primary btn-block' value='Submit' />
+            <RestrictDomainForm
+              done={() => { return true }}
+              settings={this.props.settings}
+            />
           </div>
-        </form>
-        { this.state.profileViewModal
-          ? <ProfileViewModal
-            user={this.state.userToView}
-            done={this.toggleProfileViewModal} />
-        : '' }
+          
+          <form className='ql-admin-login-box col-md-4' onSubmit={this.handleSubmit}>
+            <h4>Add user manually</h4>  
+            <div className='ql-card-content inputs-container'>
+              <div className='input-group'>
+                <input className='form-control' type='text' data-name='firstname' onChange={this.setValue} placeholder='First Name' />
+                <input className='form-control' type='text' data-name='lastname' onChange={this.setValue} placeholder='Last Name' />
+              </div>
+              <input className='form-control' id='emailField' type='email' data-name='email' onChange={this.setValue} placeholder='Email' />
+              <br />
+              <input className='form-control' id='passwordField' type='password' data-name='password' onChange={this.setValue} placeholder='Password' /><br />
+              <div><input className='form-control' type='password' data-name='password_verify' onChange={this.setValue} placeholder='Retype Password' /><br /></div>
+              <div className='spacer1'>&nbsp;</div>
+              <input type='submit' id='submitButton' className='btn btn-primary btn-block' value='Submit' />
+            </div>
+          </form>
+        </div>
+
+        <div>
+          <h1>Users (with elevated permissions first)</h1>
+          <table className='table table-bordered'>
+            <tbody>
+              <tr>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Courses</th>
+                <th>Change Role</th>
+              </tr>
+
+              {
+                this.props.allUsers.map((u) => {
+                  let courseList = ''
+                  if (u.profile.courses && this.props) {
+                    u.profile.courses.forEach(function (cId) {
+                      courseList += this.props.courseNames[cId] ? this.props.courseNames[cId] + ' ' : ''
+                    }.bind(this))
+                  }
+                  return (<tr key={u._id}>
+                    <td>
+                      <a href='#' onClick={(e) => this.toggleProfileViewModal(u)}>{u.getName()}</a>
+                    </td>
+                    <td>{u.getEmail()} &nbsp;&nbsp; {u.emails[0].verified ? '(verified)'
+                        : <a href='#' onClick={(e) => this.verifyUserEmail(u.getEmail())}>Verify</a>}
+                    </td>
+                    <td>{courseList}</td>
+                    <td>
+                      <select onChange={(e) => this.saveRoleChange(u._id, e.target.value)} value={u.getRole()}>
+                        { Object.keys(ROLES).map((r) => <option key={'role_' + ROLES[r]} value={ROLES[r]}>{ROLES[r]}</option>)}
+                      </select>
+                      &nbsp;&nbsp;{u.isInstructorAnyCourse() && u.hasRole('student') ? '(TA)' : ''}
+                    </td>
+                  </tr>)
+                })
+              }
+            </tbody>
+          </table>
+          { this.state.profileViewModal
+            ? <ProfileViewModal
+              user={this.state.userToView}
+              done={this.toggleProfileViewModal} />
+          : '' }
+        </div>
       </div>)
   }
 }

--- a/imports/ui/pages/admin/admin_dashboard.jsx
+++ b/imports/ui/pages/admin/admin_dashboard.jsx
@@ -16,6 +16,8 @@ import { ROLES } from '../../../configs'
 
 import { ProfileViewModal } from '../../modals/ProfileViewModal'
 
+import { Slingshot } from 'meteor/edgee:slingshot'
+
 class _AdminDashboard extends Component {
 
   constructor (p) {
@@ -38,6 +40,7 @@ class _AdminDashboard extends Component {
     this.handleSubmit = this.handleSubmit.bind(this)
     this.saveImageSize = this.saveImageSize.bind(this)
     this.saveImageWidth = this.saveImageWidth.bind(this)
+    this.saveCredentials = this.saveCredentials.bind(this)
     this.verifyUserEmail = this.verifyUserEmail.bind(this)
     this.toggleProfileViewModal = this.toggleProfileViewModal.bind(this)
   }
@@ -79,6 +82,19 @@ class _AdminDashboard extends Component {
     })
   }
 
+  saveCredentials (e) {
+    e.preventDefault
+
+    Meteor.call('updateCredentials', this.state.bucket, this.state.region, this.state.accessKey, this.state.secret, (err, result) => {
+      if (err) {
+        alertify.error('Error')
+      }
+      else {
+        console.log(result)
+        alertify.success('Updated')
+      }
+    })
+  }
   verifyUserEmail (email) {
     Meteor.call('users.verifyEmail', email, (e, d) => {
       if (e) alertify.error(e)
@@ -150,7 +166,7 @@ class _AdminDashboard extends Component {
         <input type='checkbox' checked={this.state.requireVerified} onChange={this.setVerified} />
 
         <h4>AWS Bucket Name</h4>
-        <form ref='supportForm' onSubmit={this.saveBucket} className='form-inline'>
+        <form ref='supportForm' onSubmit={this.saveEmail} className='form-inline'>
           <input className='form-control' value={this.state.bucket} type='text' onChange={setBucket} />
           <input type='submit' className='btn btn-primary' value='Set' />
         </form>
@@ -172,6 +188,8 @@ class _AdminDashboard extends Component {
           <input className='form-control' value={this.state.secret} type='text' onChange={setSecret} />
           <input type='submit' className='btn btn-primary' value='Set' />
         </form>
+
+        <input className='btn btn-primary' value='Set' onClick={this.saveCredentials} />
 
         <RestrictDomainForm
           done={() => { return true }}

--- a/imports/ui/pages/admin/admin_dashboard.jsx
+++ b/imports/ui/pages/admin/admin_dashboard.jsx
@@ -29,10 +29,10 @@ class _AdminDashboard extends Component {
       width: p.settings.maxImageWidth,
       supportEmail: p.settings.email,
       requireVerified: p.settings.requireVerified,
-      bucket:  p.settings.bucket,
-      region: p.settings.region,
-      accessKey: p.settings.accessKey,
-      secret: p.settings.secret
+      AWS_bucket:  p.settings.AWS_bucket,
+      AWS_region: p.settings.AWS_region,
+      AWS_accessKey: p.settings.AWS_accessKey,
+      AWS_secret: p.settings.AWS_secret,
     }
 
     this.saveRoleChange = this.saveRoleChange.bind(this)
@@ -86,10 +86,10 @@ class _AdminDashboard extends Component {
     e.preventDefault
 
     let settings = Settings.findOne()
-    settings.bucket = this.state.bucket
-    settings.region = this.state.region
-    settings.accessKey = this.state.accessKey
-    settings.secret = this.state.secret
+    settings.AWS_bucket = this.state.AWS_bucket
+    settings.AWS_region = this.state.AWS_region
+    settings.AWS_accessKey = this.state.AWS_accessKey
+    settings.AWS_secret = this.state.AWS_secret
 
     Meteor.call('settings.update', settings, (e, d) => {
       if (e) alertify.error('Error updating settings')
@@ -136,10 +136,10 @@ class _AdminDashboard extends Component {
     const setImageSize = (e) => { this.setState({ size: e.target.value }) }
     const setImageWidth = (e) => { this.setState({ width: e.target.value }) }
     const setSupportEmail = (e) => { this.setState({ supportEmail: e.target.value }) }
-    const setBucket = (e) => { this.setState({ bucket: e.target.value }) }
-    const setRegion = (e) => { this.setState({ region: e.target.value }) }
-    const setAccessKey = (e) => { this.setState({ accessKey: e.target.value }) }
-    const setSecret = (e) => { this.setState({ secret: e.target.value }) }
+    const setAWS_bucket = (e) => { this.setState({ AWS_bucket: e.target.value }) }
+    const setAWS_region = (e) => { this.setState({ AWS_region: e.target.value }) }
+    const setAWS_accessKey = (e) => { this.setState({ AWS_accessKey: e.target.value }) }
+    const setAWS_secret = (e) => { this.setState({ AWS_secret: e.target.value }) }
     
     return (
       <div className='container ql-admin-page'>
@@ -175,10 +175,10 @@ class _AdminDashboard extends Component {
             <form className='ql-admin-login-box col-md-4' onSubmit={this.saveCredentials}>
               <h4>Image Storage Settings</h4> 
               <div className='ql-card-content inputs-container'>
-                <input className='form-control' type='text' value={this.state.bucket} onChange={setBucket} placeholder='Bucket Name' /><br />
-                <input className='form-control' type='text' value={this.state.region} onChange={setRegion} placeholder='Region' /><br />
-                <input className='form-control' type='text' value={this.state.accessKey} onChange={setAccessKey} placeholder='AWS Access Key Id' /><br />
-                <input className='form-control' type='text' value={this.state.secret} onChange={setSecret} placeholder='AWS Secret' /><br />
+                <input className='form-control' type='text' value={this.state.AWS_bucket} onChange={setAWS_bucket} placeholder='AWS_bucket Name' /><br />
+                <input className='form-control' type='text' value={this.state.AWS_region} onChange={setAWS_region} placeholder='AWS_region' /><br />
+                <input className='form-control' type='text' value={this.state.AWS_accessKey} onChange={setAWS_accessKey} placeholder='AWS Access Key Id' /><br />
+                <input className='form-control' type='text' value={this.state.AWS_secret} onChange={setAWS_secret} placeholder='AWS AWS_secret' /><br />
                 <div className='spacer1'>&nbsp;</div>
                 <input type='submit' id='submitStorage' className='btn btn-primary btn-block' value='Submit' />
               </div>

--- a/imports/ui/pages/admin/admin_dashboard.jsx
+++ b/imports/ui/pages/admin/admin_dashboard.jsx
@@ -64,7 +64,6 @@ class _AdminDashboard extends Component {
     e.preventDefault()
 
     let settings = Settings.findOne()
-    console.log(settings.bucket)
     settings.maxImageSize = !isNaN(Number(this.state.size)) ? Number(this.state.size) : 0
     Meteor.call('settings.update', settings, (e, d) => {
       if (e) alertify.error('Error updating settings')

--- a/server/main.js
+++ b/server/main.js
@@ -16,7 +16,11 @@ Meteor.startup(() => {
       maxImageSize: 3,
       maxImageWidth: 700, // ROOT_URL can be https://qlicker.org:3000/ or htpps://qlicker.org/:
       email: 'admin@' + process.env.ROOT_URL.split('//')[1].split(':')[0].split('/')[0],
-      requireVerified: false
+      requireVerified: false,
+      bucket: '',
+      region: '',
+      accessKey: '',
+      secret: ''
     })
   }
 

--- a/server/slingshot.js
+++ b/server/slingshot.js
@@ -3,60 +3,27 @@ import { Slingshot } from 'meteor/edgee:slingshot'
 
 import { Settings } from '../imports/api/settings.js'
 
-// Checks if Meteor settings has the minimum required s3 credentials
-// for use with Slingshot.
-let hasS3Credentials = !!(Meteor.settings.AWSAccessKeyId &&
-    Meteor.settings.AWSSecretAccessKey &&
-    Meteor.settings.bucket)
+// This creates an AWS S3 storage with no credentials
+// Credentials can be changed in admin_dashboard
 
-if (hasS3Credentials) {
-  Slingshot.createDirective('QuestionImages', Slingshot.S3Storage, {
-    allowedFileTypes: ['image/png', 'image/jpeg', 'image/jpg', 'image/gif'],
-    maxSize: null, // Unlimited, handled in authorized() instead
-    bucket: Meteor.settings.bucket,
-    acl: 'public-read',
+Slingshot.createDirective('QuestionImages', Slingshot.S3Storage, {
+  
+  allowedFileTypes: ['image/png', 'image/jpeg', 'image/jpg', 'image/gif'],
+  maxSize: null, // Unlimited, handled in authorized() instead
+  bucket: '',
+  AWSAccessKeyId: '',
+  AWSSecretAccessKey: '',
+  acl: 'public-read',
 
-    authorize: function (file, metaContext) {
-      if (file.size > (Settings.findOne().maxImageSize * 1024 * 1024)) {
-        alertify.error('Image too large')
-        return false
-      }
-      return Meteor.userId()
-    },
-
-    key: function (file, metaContext) {
-      return metaContext.UID + '/' + metaContext.type
+  authorize: function (file, metaContext) {
+    if (file.size > (Settings.findOne().maxImageSize * 1024 * 1024)) {
+      alertify.error('Image too large')
+      return false
     }
-  })
-} else {
-  // This creates an AWS S3 storage with no credentials
-  // Credentials can be changed in admin_dashboard
+    return Meteor.userId()
+  },
 
-  Slingshot.createDirective('QuestionImages', Slingshot.S3Storage, {
-   
-    allowedFileTypes: ['image/png', 'image/jpeg', 'image/jpg', 'image/gif'],
-    maxSize: null, // Unlimited, handled in authorized() instead
-    bucket: '',
-    AWSAccessKeyId: '',
-    AWSSecretAccessKey: '',
-    acl: 'public-read',
-
-    authorize: function (file, metaContext) {
-      if (file.size > (Settings.findOne().maxImageSize * 1024 * 1024)) {
-        alertify.error('Image too large')
-        return false
-      }
-      return Meteor.userId()
-    },
-
-    key: function (file, metaContext) {
-      return metaContext.UID + '/' + metaContext.type
-    }
-  })
-
-  console.warn(
-    'WARNING: ' +
-    'Missing S3 credentials in meteor settings. File uploading' +
-    ' will not work. This is fine if you are doing some sort of minor' +
-    ' testing. Do NOT deploy if you are seeing this message in prod!')
-}
+  key: function (file, metaContext) {
+    return metaContext.UID + '/' + metaContext.type
+  }
+})


### PR DESCRIPTION
No longer required to run `meteor --settings settings.json`. Instead, run `meteor`, and input AWS credentials in the admin dashboard.

This PR does not include any changes to supporting other storage solutions, but just gets rid of the need for settings.json.

EDIT: There seems to be an issue with image uploading in the question library.
EDIT 2: The error seems to be coming from rapidly switching AWS buckets. I think it would be best to deal with this later.