### PR TITLE
SSO implemented

### DIFF
--- a/client/saml_client.js
+++ b/client/saml_client.js
@@ -1,9 +1,13 @@
 import { Random } from 'meteor/random'
 
+//Create a saml object in acccounts if it does not exist
 if (!Accounts.saml) {
   Accounts.saml = {};
 }
 
+//Open a popup with the redirect request to the IDP for SSO login
+//Popup will be closed when the server receives a valid POST response
+//at the /SSO/SAML route (see server/saml_server.js)
 Accounts.saml.initiateLogin = function(options, callback, dimensions) {
   // default dimensions that worked well for facebook and google
   var popup = openCenteredPopup(
@@ -50,7 +54,11 @@ var openCenteredPopup = function(url, width, height) {
 };
 
 
-
+//Wrapper for callLoginMethod, which opens the popup and calls the login handler
+//with the generated credential token
+//The random token is passed as RelayState to the IDP (see initiateLogin above),
+//and then back to the server by the IDP. This allows the server to identify
+//this client as the one starting the login request
 Meteor.loginWithSaml = function(options, callback) {
   options = options || {};
   options.credentialToken = Random.secret(); 

--- a/imports/api/settings.js
+++ b/imports/api/settings.js
@@ -55,7 +55,7 @@ if (Meteor.isServer) {
       if (user.hasGreaterRole(ROLES.admin)) {
         return Settings.find()
       }
-    } else return [] 
+    } else this.ready()
   })
 
   Accounts.validateLoginAttempt((options) => {
@@ -146,11 +146,16 @@ Meteor.methods({
     }
   },
 
-  'settings.getInstitution' () {
+  'settings.getSSOInstitution' () {
     const settings = Settings.findOne()
     if (settings) return settings.SSO_institutionName
   },
 
+   'settings.getSSOEnabled' () {
+    const settings = Settings.findOne()
+    if (settings) return settings.SSO_enabled
+  }, 
+   
   'confirmAccount' (email) {
     check(email, String)
     var domain = email.substring(email.lastIndexOf('@') + 1)

--- a/imports/startup/client/routes.jsx
+++ b/imports/startup/client/routes.jsx
@@ -51,6 +51,23 @@ Router.route('/login', {
   }
 })
 
+Router.route('/login/email', {
+  name: 'login.email',
+  waitOn: function () {
+    return Meteor.subscribe('userData')
+  },
+  action: function () {
+    if (Meteor.userId()) {
+      // TODO: These should all go to the same page, for example, a user could be a professor
+      // for some courses and a student for others, as well as an admin...
+      let user = Meteor.user()
+      if (user.hasRole('admin')) Router.go('admin')
+      if (user.hasRole('professor')) Router.go('professor')
+      if (user.hasRole('student')) Router.go('student')
+    } else mount(AppLayout, { content: <Loginpage allowEmailLogin={true} /> })
+  }
+})
+
 Router.route('/logout', {
   name: 'logout',
   action: function () {

--- a/imports/startup/client/routes.jsx
+++ b/imports/startup/client/routes.jsx
@@ -93,7 +93,7 @@ Router.route('/profile', {
   action: function () {
     let user = Meteor.user()
     if (user) {
-      mount(AppLayout, { content: <PageContainer user={user}> <ProfilePage /> </PageContainer> })
+      mount(AppLayout, { content: <PageContainer > <ProfilePage /> </PageContainer> })
     } else Router.go('login')
   }
 })

--- a/imports/ui/LoginBox.jsx
+++ b/imports/ui/LoginBox.jsx
@@ -33,8 +33,19 @@ export class LoginBox extends Component {
     this.changeForm = this.changeForm.bind(this)
     this.sendVerificationEmail = this.sendVerificationEmail.bind(this)
     this.loginSSO = this.loginSSO.bind(this)
+    //this.setState({ ssoInstitution: this.props.ssoInstitution })
+    //this.setState({ ssoEnabled: this.props.ssoEnabled})
   }
-
+  /*  
+  componentWillMount () {
+    Meteor.call('settings.getSSOInstitution', (err, institution) => {
+      this.setState({ ssoInstitution: institution})
+    })
+    Meteor.call('settings.getSSOEnabled', (err, result) => {
+      this.setState({ ssoEnabled: result})
+    })  
+  }*/
+    
   loginSSO(e){
    e.preventDefault()
    Meteor.loginWithSaml()
@@ -110,17 +121,16 @@ export class LoginBox extends Component {
     this.setState(stateEdits)
   }
 
-  componentWillMount () {
-    Meteor.call('settings.getInstitution', (err, institution) => {
-      this.setState({ ssoInstitution: institution})
-    })
-  }
-  
+  //Only show create account link if SSO is disabled
+  //Only show login through SSO if SSO is enabled
+  //Only show login with email if requested by route when SSO is enabled
+
   render () {
     const switchFormString = this.state.login ? 'Create an Account' : 'Login'
     const submitButtonString = this.state.login ? 'Login' : 'Sign Up'
     const topMessage = this.state.login ? 'Login to Qlicker' : 'Register for Qlicker'
-    const haveAccountMessage = this.state.login ? 'Don\'t have an account?' : 'Already have an account?'
+    const haveAccountMessage = this.state.login ? 'Don\'t have an account?' : 'Already have an account?'   
+    
     return (
       <form className='ql-login-box ql-card' onSubmit={this.handleSubmit}>
         <div className='header-container ql-header-bar'>
@@ -132,19 +142,31 @@ export class LoginBox extends Component {
               <input className='form-control' type='text' data-name='firstname' onChange={this.setValue} placeholder='First Name' />
               <input className='form-control' type='text' data-name='lastname' onChange={this.setValue} placeholder='Last Name' />
             </div> : '' }
+          { this.props.allowEmailLogin ?
+          <div>
+            <input className='form-control' id='emailField' type='email' data-name='email' onChange={this.setValue} placeholder='Email' /><br />
 
-          <input className='form-control' id='emailField' type='email' data-name='email' onChange={this.setValue} placeholder='Email' /><br />
+            <input className='form-control' id='passwordField' type='password' data-name='password' onChange={this.setValue} placeholder='Password' /><br />
+            { !this.state.login ? <div><input className='form-control' type='password' data-name='password_verify' onChange={this.setValue} placeholder='Retype Password' /><br /></div> : ''}
 
-          <input className='form-control' id='passwordField' type='password' data-name='password' onChange={this.setValue} placeholder='Password' /><br />
-          { !this.state.login ? <div><input className='form-control' type='password' data-name='password_verify' onChange={this.setValue} placeholder='Retype Password' /><br /></div> : ''}
-
-          { this.state.form_error ? <div className='ql-login-box-error-msg'>Please enter a valid email and password</div> : ''}
-          { this.state.submit_error ? <div className='ql-login-box-error-msg'>An error occurred</div> : ''}
-          <div className='spacer1'>&nbsp;</div>
-          <input type='submit' id='submitButton' className='btn btn-primary btn-block' value={submitButtonString} />
-          <div className='bottom-account-message'>{haveAccountMessage}</div>
-          <button className='ql-switch-form-button btn btn-default btn-block' onClick={this.changeForm}>{switchFormString}</button>
-          <button className='ql-switch-form-button btn btn-default btn-block' onClick={this.loginSSO}>Login through {this.state.ssoInstitution}</button>
+            { this.state.form_error ? <div className='ql-login-box-error-msg'>Please enter a valid email and password</div> : ''}
+            { this.state.submit_error ? <div className='ql-login-box-error-msg'>An error occurred</div> : ''}
+            <div className='spacer1'>&nbsp;</div>
+            <input type='submit' id='submitButton' className='btn btn-primary btn-block' value={submitButtonString} />
+          </div> : '' }
+          
+          { this.props.ssoEnabled ? '' : 
+            <div>
+              <div className='bottom-account-message'>{haveAccountMessage}</div>
+              <button className='ql-switch-form-button btn btn-default btn-block' onClick={this.changeForm}>{switchFormString}</button>
+            </div>
+          }
+             
+          { this.props.ssoEnabled ?
+                <button className='ql-switch-form-button btn btn-default btn-block' onClick={this.loginSSO}>
+                    Login through {this.props.ssoInstitution ? this.props.ssoInstitution : 'SSO'}
+                </button> : '' 
+           }
         </div>
       </form>
     )

--- a/imports/ui/pages/login.jsx
+++ b/imports/ui/pages/login.jsx
@@ -16,8 +16,23 @@ export class Loginpage extends Component {
 
     this.state = { resetPassword: false }
   }
-
+    
+  componentWillMount () {
+    Meteor.call('settings.getSSOInstitution', (err, institution) => {
+      this.setState({ ssoInstitution: institution})
+    })
+    Meteor.call('settings.getSSOEnabled', (err, result) => {
+      this.setState({ ssoEnabled: result})
+    })  
+  }
+    
   render () {
+    //Allow email login if it was passed as a prop, or if SSO is not enabled
+    //It is passed a prop in the login/email route
+    const allowEmailLogin = this.props.allowEmailLogin || !this.state.ssoEnabled ? true : false
+    const ssoInstitution = this.state.ssoInstitution
+    const ssoEnabled = this.state.ssoEnabled
+      
     const togglePasswordResetModal = () => { this.setState({ resetPassword: !this.state.resetPassword }) }
     return (
       <div className='ql-login-page'>
@@ -30,11 +45,16 @@ export class Loginpage extends Component {
             </div>
 
             <div className='col-md-4 login-container'>
-              <LoginBox />
+              <LoginBox ssoEnabled={ssoEnabled} ssoInstitution={ssoInstitution} allowEmailLogin={allowEmailLogin}/>
               <br />
-              <div className='center-text'>
-                <a href='#' onClick={togglePasswordResetModal} >Forgot your password?</a>
-              </div>
+              { allowEmailLogin ?
+                <div className='center-text'>
+                  <a href='#' onClick={togglePasswordResetModal} >Forgot your password?</a>
+                </div> : 
+                <div className='center-text'>
+                  <a href={Router.routes['login.email'].path()} >Have an email based account?</a>
+                </div>
+               }
             </div>
 
             <div className='col-md-4'>&nbsp;

--- a/imports/ui/pages/page_container.jsx
+++ b/imports/ui/pages/page_container.jsx
@@ -163,7 +163,7 @@ class _PageContainer extends Component {
                     <img src={user.getThumbnailUrl()} className='nav-profile img-circle' /> {user.getName()} <span className='caret' />
                   </a>
                   <ul className='dropdown-menu'>
-                    <li><a className='close-nav' href={Router.routes['profile'].path()}>Edit user profile</a></li>
+                    <li><a className='close-nav' href={Router.routes['profile'].path()}>User profile</a></li>
                     {isProfessor
                       ? <li><a className='close-nav' href='#' onClick={togglePromotingAccount}>Promote an account to professor</a></li>
                       : ''

--- a/imports/ui/pages/page_container.jsx
+++ b/imports/ui/pages/page_container.jsx
@@ -21,6 +21,7 @@ class _PageContainer extends Component {
       courseId: this.props && this.props.courseId ? this.props.courseId : '',
       courseCode: '',
       ssoLogoutUrl: null,
+      ssoInstitution: null,
       showCourse: this.props && this.props.courseId ? true : false
     }
     alertify.logPosition('bottom right')
@@ -31,9 +32,7 @@ class _PageContainer extends Component {
     if(this.state.courseId !== '') {
       this.setCourseCode(this.state.courseId)
     }
-    Meteor.call("getSSOLogoutUrl", (err,result) => {
-      if(!err) this.setState({ssoLogoutUrl:result})
-    })
+    
   }
   
   setCourseCode (courseId) {
@@ -44,6 +43,17 @@ class _PageContainer extends Component {
     })
   }
 
+  componentWillMount () {
+    Meteor.call("getSSOLogoutUrl", (err,result) => {
+      if(!err){
+        this.setState({ssoLogoutUrl:result})
+        Meteor.call("settings.getSSOInstitution", (err2,name) => {
+          if(!err2)this.setState({ssoInstitution:name})
+        })
+      }
+    })   
+  }
+    
   componentDidMount () {
     // Close the dropdown when selecting a link during mobile
     // view.
@@ -65,6 +75,7 @@ class _PageContainer extends Component {
 
   render () {
     const user = Meteor.user()
+    if(!user)  Router.go('logout')
     const isInstructor = user.isInstructorAnyCourse() // to view student submissions
     const isProfessor = user.hasGreaterRole('professor') // to promote accounts
     const isAdmin = user.hasRole('admin')
@@ -159,8 +170,11 @@ class _PageContainer extends Component {
                     }
                     <li><a className='close-nav' href={userGuideUrl}>Visit user guide</a></li>
                     <li role='separator' className='divider' />
-                    <li><a className='close-nav' href={Router.routes['logout'].path()} onClick={logout} >Logout</a></li>
-                    {this.state.ssoLogoutUrl ? <li><a className='close-nav' href={this.state.ssoLogoutUrl}> Logout from SSO</a></li> : ''} 
+                    <li><a className='close-nav' href={Router.routes['logout'].path()} onClick={logout} >Logout from Qlicker</a></li>
+                    {this.state.ssoLogoutUrl ?
+                          <li><a className='close-nav' href={this.state.ssoLogoutUrl}> Logout from Qlicker and {this.state.ssoInstitution ? this.state.ssoInstitution : 'SSO' }</a></li> 
+                          : ''
+                    } 
                   </ul>
                 </li>
               </ul>
@@ -182,7 +196,6 @@ export const PageContainer = createContainer(props => {
   const handle = Meteor.subscribe('courses')
   const courses = Courses.find({ inactive: { $in: [null, false] } }).fetch()   
 
-    
   return {
     courses: courses,
     courseId: props.courseId,

--- a/imports/ui/pages/profile.jsx
+++ b/imports/ui/pages/profile.jsx
@@ -33,6 +33,13 @@ class _Profile extends Component {
     this.resizeImage = this.resizeImage.bind(this)
     this.updateProfileImage = this.updateProfileImage.bind(this)
   }
+    
+  componentWillMount () {
+    //If the SSOlogout URL exists, user is logged in through SSO, don't let them change their password!
+    Meteor.call("isSSOSession", (err,result) => {
+      if(!err)this.setState({isSSOSession:result})
+    })   
+  }  
 
   updateProfileImage (file, done) {
     let reader = new window.FileReader()
@@ -140,7 +147,8 @@ class _Profile extends Component {
     const toggleUpload = () => { this.setState({ uploadActive: !this.state.uploadActive }) }
     const toggleChangeEmailModal = () => { this.setState({ changingEmail: !this.state.changingEmail }) }
     const toggleChangePasswordModal = () => { this.setState({ changingPassword: !this.state.changingPassword }) }
-
+    const noEdits = this.state.isSSOSession
+    
     const spanVerified = user.emails[0].verified
       ? <span className='label label-success'>Verified</span>
       : <span className='label label-warning'>Un-verified</span>
@@ -161,7 +169,7 @@ class _Profile extends Component {
 
             <div className='ql-profile-card ql-card'>
               <div className='profile-header ql-header-bar'>
-                <h4>Edit User Profile</h4>
+                <h4> User Profile</h4>
               </div>
 
               <div className='ql-card-content'>
@@ -187,10 +195,13 @@ class _Profile extends Component {
                     }
                 </div>
 
-                <div className='btn-group btn-group-justified' role='group' aria-label='...'>
-                  <a href='#' className='btn btn-default' onClick={toggleChangeEmailModal} >Change Email</a>
-                  <a href='#' className='btn btn-default' onClick={toggleChangePasswordModal} >Change Password</a>
-                </div>
+                
+                { noEdits ? '' :
+                  <div className='btn-group btn-group-justified' role='group' aria-label='...'>
+                    <a href='#' className='btn btn-default' onClick={toggleChangeEmailModal} >Change Email</a>
+                    <a href='#' className='btn btn-default' onClick={toggleChangePasswordModal} >Change Password</a>
+                  </div>
+                 }
                 <br />
                 <h2>{user.getName()}</h2>
                 <div className='ql-profile-container'>

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "streamsearch": "^0.1.2",
     "syntastic-react": "^1.0.3",
     "underscore": "^1.9.1",
-    "uuid-1345": "^0.99.7"
+    "uuid-1345": "^0.99.7",
+    "xmldom": "^0.1.27"
   },
   "devDependencies": {
     "codecov": "^1.0.1",

--- a/server/main.js
+++ b/server/main.js
@@ -28,8 +28,9 @@ Meteor.startup(() => {
     })
   } else {
     const settings = Settings.findOne()
-    let directive = Slingshot.getDirective(settings.storageType)._directive
-    if (settings.storageType === 'AWS') {      
+    let directive = {}
+    if (settings.storageType === 'AWS') {  
+      directive = Slingshot.getDirective(settings.storageType)._directive  
       if (!directive) throw new Error('No Directive')
       directive.bucket = settings.AWS_bucket
       directive.region = settings.AWS_region
@@ -37,6 +38,7 @@ Meteor.startup(() => {
       directive.AWSSecretAccessKey = settings.AWS_secret
     }
     if (settings.storageType === 'Azure') {
+      directive = Slingshot.getDirective(settings.storageType)._directive
       if (!directive) throw new Error('No Directive')
       directive.accountName = settings.Azure_accountName
       directive.accountKey = settings.Azure_accountKey

--- a/server/saml_server.js
+++ b/server/saml_server.js
@@ -13,20 +13,8 @@ console.log(Meteor.absoluteUrl())
 
 settings = Settings.findOne({})
 
-/* Testing */
-//console.log(settings)
-SAMLRequest = Assets.getText('SAMLRequest')
-var xml = new Buffer(SAMLRequest, 'base64').toString('utf8');
-var dom = new xmldom.DOMParser().parseFromString(xml); 
-var sessionIndex = xpath(dom, "/*[local-name()='LogoutRequest']/*[local-name()='SessionIndex']/text()")[0].data;
-
-
-
-
-
-/* End testing */
-
-//Only if SSO is enabled, set things up:
+//Only if SSO is enabled, set things up
+//These setting take effect only after restarting the app, if the SSO is enabled/disabled
 if(settings.SSO_enabled && settings.SSO_emailIdentifier && settings.SSO_entrypoint && settings.SSO_identifierFormat ){
     
 //Create a passport-saml strategy using the given settings
@@ -35,15 +23,15 @@ if(settings.SSO_enabled && settings.SSO_emailIdentifier && settings.SSO_entrypoi
     
   strategy = new saml.Strategy({
     callbackUrl: Meteor.absoluteUrl('SSO/SAML2'),
-    logoutCallbackUrl: Meteor.absoluteUrl('logout'),
+    logoutCallbackUrl: Meteor.absoluteUrl('logout'), //TODO: update this to SSO/SAML2/logout
     entryPoint: settings.SSO_entrypoint,
     cert: settings.SSO_cert,
     identifierFormat: settings.SSO_identifierFormat,
-    logoutUrl: (settings.SSO_logoutUrl ? settings.SSO_logoutUrl : settings.SSO_entrypoint),
+    logoutUrl: (settings.SSO_logoutUrl ? settings.SSO_logoutUrl : ''),
       
     //privateCert: Assets.getText('key.key'),
     decryptionPvk: Assets.getText('key.key'),
-    issuer: 'passport-saml' // call this Qlicker, not passport-saml!
+    issuer: 'passport-saml' // TODO: call this Qlicker, not passport-saml!
     },
     function(profile, done) {
     return done(null, profile);
@@ -59,29 +47,31 @@ if(settings.SSO_enabled && settings.SSO_emailIdentifier && settings.SSO_entrypoi
   //LoginResultForCredentialToken stores {token: {profile, nameID, sessionIndex}}
   //The token is created by the client, passed as RelayState to the IDP, and then 
   //accessed again on the server; this is how the server know the request from the IDP
-  //goes with a particular client
+  //goes with a particular client login attempt
   Accounts.saml._loginResultForCredentialToken = {};
 
-  // Inserted during IdP -> SP Callback
+  //Inserted during IdP -> SP Callback
   Accounts.saml.insertCredential = function (credentialToken, samlInfo) {
     Accounts.saml._loginResultForCredentialToken[credentialToken] = samlInfo;
   }
 
-  // Retrieved in account login handler
+  //Retrieved in account login handler
   Accounts.saml.retrieveCredential = function(credentialToken) {
     let profile = Accounts.saml._loginResultForCredentialToken[credentialToken];
     delete Accounts.saml._loginResultForCredentialToken[credentialToken];
     return profile;
   };
 
-  //Register a login handler with Meteor (gets called by client, in loginWithSaml
+  //Register a login handler with Meteor (gets called by client, in loginWithSaml through
+  //Accounts.callLoginMethod)
   Accounts.registerLoginHandler(function (loginRequest) {
+    //Check if the login request is consistent with an SSO request
     if (loginRequest.credentialToken && loginRequest.saml) {
       const samlInfo = Accounts.saml.retrieveCredential(loginRequest.credentialToken);     
       if (samlInfo) {
+        //Try to find a user based on the SAML email addresss, otherwise, create a new user  
         const samlProfile = samlInfo.profile
         let userId = null
-          //let user = Meteor.users.findOne({ "emails.address" : samlProfile.email })
         let user = Accounts.findUserByEmail(samlProfile.email)
         let profile = (user && user.profile) ? user.profile : samlProfile
         let services = { sso: {id: samlInfo.nameID, nameIDFormat: samlInfo.nameIDFormat } }
@@ -91,6 +81,7 @@ if(settings.SSO_enabled && settings.SSO_emailIdentifier && settings.SSO_entrypoi
           for (key in samlProfile){
             profile[key] = samlProfile[key]   
           }  
+          //Note that it will not actually update the email address, since the user was found by email address  
           Meteor.users.update(userId, {$set: {email: profile.email,
                                               'emails.0.verified': true,
                                               profile: profile,
@@ -111,10 +102,9 @@ if(settings.SSO_enabled && settings.SSO_emailIdentifier && settings.SSO_entrypoi
         let hashStampedToken = Accounts._hashStampedToken(stampedToken)
         Meteor.users.update(userId, { $push: { 'services.resume.loginTokens': hashStampedToken},
                                       $set: { 'services.sso.session': {sessionIndex: samlInfo.sessionIndex,
-                                                                         loginToken: hashStampedToken.hashedToken }}})
-   
-        user = Meteor.users.findOne(userId)
-        console.log(user)
+                                                                       loginToken: hashStampedToken.hashedToken }}})   
+        //user = Meteor.users.findOne(userId)
+        //console.log(user)
         return {
           userId: userId,
           token: stampedToken.token
@@ -125,9 +115,12 @@ if(settings.SSO_enabled && settings.SSO_emailIdentifier && settings.SSO_entrypoi
     }
   })
 
-
+  //This method provides a link to the SSO logout with the required SAML request.
+  //This is the link that goes with the Logout From SSO button in page_container
+  //This is based on what was done in https://github.com/lucidprogrammer/meteor-saml-sp/blob/master/src/server/samlServerHandler.js
   Meteor.methods({
    "getSSOLogoutUrl": (callback) => {
+      if (settings.SSO_logoutUrl === '') return null
       user = Meteor.user()
       if (!user || !user.services || !user.services.sso || !user.services.sso.session || !user.services.sso.session.sessionIndex) return null
       var getLogoutLinkSync =  Meteor.wrapAsync(getSSLogoutAsync);
@@ -140,6 +133,7 @@ if(settings.SSO_enabled && settings.SSO_emailIdentifier && settings.SSO_entrypoi
       let request  = {user : {nameID : user.services.sso.id , nameIDFormat: user.services.sso.nameIDFormat, sessionIndex: user.services.sso.session.sessionIndex}  };
       let getLogout = Accounts.samlStrategy._saml.getLogoutUrl(request, function(error,url){
          if(error) console.log(error);
+         //The IDP POST request results in the logout and erasing the session, so no need to do it here
          //console.log("url");
          //console.log(url);
          /*Fiber(function () {
@@ -149,26 +143,30 @@ if(settings.SSO_enabled && settings.SSO_emailIdentifier && settings.SSO_entrypoi
        })
   }
 
+  //Add server side routes to handle the SSO stuff
   WebApp.connectHandlers
     .use(bodyParser.urlencoded({ extended: false }))
-    .use('/logout', function(req, res, next) {     
+    .use('/logout', function(req, res, next) {
+      //TODO: Move this code to SSO/SAML2/logout route and update the corresponding logout URL in the settings!!!!
       Fiber(function() {
         if (req.method === 'POST') {  
+          //----------- Hack start
           //A hack to bypass the SSO stuff and log the user out from the IDP POST request
           //(needed because passport-saml cannot validate the encrypted response)
           //WARNING: This does not do any safety checks on the request passed by the IDP!!!
           let xml = new Buffer(req.body.SAMLRequest, 'base64').toString('utf8');
           let dom = new xmldom.DOMParser().parseFromString(xml); 
           let sessionIndex = xpath(dom, "/*[local-name()='LogoutRequest']/*[local-name()='SessionIndex']/text()")[0].data;
-            console.log("log out hack")
+            //console.log("log out hack")
           let user = Meteor.users.findOne({ 'services.sso.session.sessionIndex':sessionIndex })
-            console.log(user)
+            //console.log(user)
           if(user){ //remove the session ID and the login token
             Meteor.users.update({_id:user._id},{ $set: {'services.sso.session': {}, 'services.resume.loginTokens' : [] } })
           }
-          console.log(user)
+            //console.log(user)
           res.writeHead(302, {'Location': Meteor.absoluteUrl('login')});
           res.end()
+          //----------- Hack end
           /* 
           //The code below should run instead of the hack above!!!
           Accounts.samlStrategy._saml.validatePostRequest(req.body, function(err, result){
@@ -199,51 +197,68 @@ if(settings.SSO_enabled && settings.SSO_emailIdentifier && settings.SSO_entrypoi
       Fiber(function() {
         try {     
           if (req.method === 'GET') {
-            // send the metadata
+            // send the metadata if metadata is in the path
             if (url.parse(req.url).pathname === '/metadata' || url.parse(req.url).pathname === '/metadata.xml') {
               res.writeHead(200, {'Content-Type': 'application/xml'});
               const decryptionCert = Assets.getText('cert.cert');
               res.end(Accounts.samlStrategy._saml.generateServiceProviderMetadata(decryptionCert), 'utf-8');
             } else {
-              // redirect to IdP (SP -> IdP)
+              // Otherwise redirect to IdP for login (SP -> IdP) (IDP responds with a POST handled below)
+              // This route gets called by the login popup window - otherwise, the RelayState will not be set.
               Accounts.samlStrategy._saml.getAuthorizeUrl(req, function (err, result) {
                 res.writeHead(302, {'Location': result});
                 res.end();
               });
             }
           }
-          // callback from IdP (IdP -> SP) to either logout or login
+          // POST callback from IdP (IdP -> SP) to either logout or login
           else if (req.method === 'POST') { 
             if (url.parse(req.url).pathname === '/logout') {
+              //----------- Hack start
+              //A hack to bypass the SSO stuff and log the user out using the SessionIndex in the IDP POST request
+              //(needed because passport-saml cannot validate the encrypted response)
+              //WARNING: This does not check that the POST came from the IDP
+              let xml = new Buffer(req.body.SAMLRequest, 'base64').toString('utf8');
+              let dom = new xmldom.DOMParser().parseFromString(xml); 
+              let sessionIndex = xpath(dom, "/*[local-name()='LogoutRequest']/*[local-name()='SessionIndex']/text()")[0].data;
+                //console.log("log out hack")
+              let user = Meteor.users.findOne({ 'services.sso.session.sessionIndex':sessionIndex })
+                //console.log(user)
+              if(user){ //remove the session ID and the login token
+                Meteor.users.update({_id:user._id},{ $set: {'services.sso.session': {}, 'services.resume.loginTokens' : [] } })
+              }
+                //console.log(user)
+              res.writeHead(302, {'Location': Meteor.absoluteUrl('login')});//this does not work, probably need a different response
+              res.end()
+              //----------- Hack end
+              //The code below should be used instead of the hack above!!! It should work if we disable encryption
+              //by not setting decryptionPvk in the SAML strategy. However, decryptionPvk is required to generate the
+              //metadata, so we would have to manually edit the metadata  
+              /* 
               Accounts.samlStrategy._saml.validatePostRequest(req.body, function(err, result){
                 if(!err){ //based on https://github.com/lucidprogrammer/meteor-saml-sp/blob/master/src/server/samlServerHandler.js
+                  console.log("validating post request")
                   console.log(result)
-                  let user = Meteor.users.findOne({ 'services.sso.sessions': {$elementMatch: {sessionIndex: result['sessionIndex']} }  }) 
-                  if(user){
-                    Meteor.users.update({_id:user._id},{ $pull: {'services.saml.sessions': {sessionIndex: result['sessionIndex']} },
-                                                         $set: {'services.resume.loginTokens' : []} } );  
-                    
+                  let user = Meteor.users.findOne({ 'services.sso.session.sessionIndex':result['sessionIndex'] }) 
+                  if(user){ //remove the session ID and the login token
+                    Meteor.users.update({_id:user._id},{ $set: {'services.sso.session': {}, 'services.resume.loginTokens' : [] } })
                   }
                   Accounts.samlStrategy._saml.getLogoutResponseUrl(req, function(err, logout){
                     if(error) throw new Error("Unable to generate logout response url");
                     res.writeHead(302, {'Location': logout});
                     res.end()
                   })
+                } else {
+                 console.log(err)  
+                 console.log(result)
                 }
-              })
+              }) */ // end of validate post request
                   
-            } else { //logging in
-                
-              //var xml = new Buffer(req.body.SAMLResponse, 'base64').toString('utf8');
-              //console.log(xml)  
-              //var doc = new xmldom.DOMParser().parseFromString(xml); 
-              //console.log(doc)
-                
-              ///////////////
+            } else {//POST request for login:
               Accounts.samlStrategy._saml.validatePostResponse(req.body, function (err, result) {
                 if (!err) {
-                  console.log(result) 
-                  email = result[settings.SSO_emailIdentifier] 
+                  //console.log(result) 
+                  email = result[settings.SSO_emailIdentifier] //settings.SSO_emailIdentifier has to be specified (see if at top)
                   firstname = settings.SSO_firstNameIdentifier ? result[settings.SSO_firstNameIdentifier] : 'Brice'
                   lastname = settings.SSO_lastNameIdentifier ? result[settings.SSO_lastNameIdentifier] : 'de Nice' 
                     

--- a/server/saml_server.js
+++ b/server/saml_server.js
@@ -9,7 +9,7 @@ import url from 'url'
 import xmldom from 'xmldom'
 import xpath from 'xpath'
 
-console.log(Meteor.absoluteUrl())
+//console.log(Meteor.absoluteUrl())
 
 settings = Settings.findOne({})
 
@@ -126,7 +126,11 @@ if(settings.SSO_enabled && settings.SSO_emailIdentifier && settings.SSO_entrypoi
       var getLogoutLinkSync =  Meteor.wrapAsync(getSSLogoutAsync);
       var result = getLogoutLinkSync(user);
       return result;
-   }
+    },
+    "isSSOSession": () =>{
+      user = Meteor.user()
+      return (user && user.services && user.services.sso && user.services.sso.session && user.services.sso.session.sessionIndex)
+    }
   })
 
   let getSSLogoutAsync = function(user, callback){
@@ -273,7 +277,7 @@ if(settings.SSO_enabled && settings.SSO_emailIdentifier && settings.SSO_entrypoi
                   res.writeHead(200, {'Content-Type': 'text/html'});
                   res.end("<html><head><script>window.close()</script></head></html>'", 'utf-8');  
                 } else {
-                  console.log(err)
+                    //console.log(err)
                   res.writeHead(500, {'Content-Type': 'text/html'});
                   res.end("An error occured in the SAML Middleware process.", 'utf-8');
                 }

--- a/server/saml_server.js
+++ b/server/saml_server.js
@@ -160,10 +160,13 @@ if(settings.SSO_enabled && settings.SSO_emailIdentifier && settings.SSO_entrypoi
           let xml = new Buffer(req.body.SAMLRequest, 'base64').toString('utf8');
           let dom = new xmldom.DOMParser().parseFromString(xml); 
           let sessionIndex = xpath(dom, "/*[local-name()='LogoutRequest']/*[local-name()='SessionIndex']/text()")[0].data;
-          let user = Meteor.users.findOne({ 'services.sso.session.sessionIndex':result['sessionIndex'] })
+            console.log("log out hack")
+          let user = Meteor.users.findOne({ 'services.sso.session.sessionIndex':sessionIndex })
+            console.log(user)
           if(user){ //remove the session ID and the login token
             Meteor.users.update({_id:user._id},{ $set: {'services.sso.session': {}, 'services.resume.loginTokens' : [] } })
           }
+          console.log(user)
           res.writeHead(302, {'Location': Meteor.absoluteUrl('login')});
           res.end()
           /* 


### PR DESCRIPTION
- Fixed settings issue when storageType does not exist 
- Additional logout button for SSO when applicable
- Implemented a hack for the IDP initiated logout (passport-saml cannot read the encrypted request)
- Login page does not allow account creation if SSO is enabled (SSO is disabled on a fresh install, allowing the first user/admin to be created)
- Added /login/email route if a non SSO account wants to login when SSO is enabled
- When SSO is enabled, only SSO login button is shown by default in /login page