### PR TITLE
Sso update

### DIFF
--- a/imports/api/settings.js
+++ b/imports/api/settings.js
@@ -40,7 +40,9 @@ const pattern = {
   SSO_emailIdentifier: Match.Maybe(String),
   SSO_firstNameIdentifier: Match.Maybe(String),
   SSO_lastNameIdentifier: Match.Maybe(String),
-  SSO_institutionName: Match.Maybe(String)
+  SSO_institutionName: Match.Maybe(String),
+  SSO_roleIdentifier: Match.Maybe(String),
+  SSO_studentNumberIdentifier: Match.Maybe(String),
 }
 
 // Create course class

--- a/imports/api/settings.js
+++ b/imports/api/settings.js
@@ -43,6 +43,7 @@ const pattern = {
   SSO_institutionName: Match.Maybe(String),
   SSO_roleIdentifier: Match.Maybe(String),
   SSO_studentNumberIdentifier: Match.Maybe(String),
+  SSO_roleProfName: Match.Maybe(String), // name of the role in the SSO system that corresponds to a professor role
 }
 
 // Create course class

--- a/imports/ui/ManageSSO.jsx
+++ b/imports/ui/ManageSSO.jsx
@@ -25,7 +25,9 @@ export class ManageSSO extends Component {
       SSO_institutionName: props.settings.SSO_institutionName,
       SSO_emailIdentifier: props.settings.SSO_emailIdentifier,
       SSO_firstNameIdentifier: props.settings.SSO_firstNameIdentifier,
-      SSO_lastNameIdentifier: props.settings.SSO_lastNameIdentifier
+      SSO_lastNameIdentifier: props.settings.SSO_lastNameIdentifier,
+      SSO_roleIdentifier: props.settings.SSO_roleIdentifier,
+      SSO_studentNumberIdentifier: props.settings.SSO_studentNumberIdentifier,
     }
 
     this.setValue = this.setValue.bind(this)
@@ -55,7 +57,9 @@ export class ManageSSO extends Component {
       SSO_emailIdentifier: this.state.SSO_emailIdentifier || '',
       SSO_firstNameIdentifier: this.state.SSO_firstNameIdentifier || '',
       SSO_lastNameIdentifier: this.state.SSO_lastNameIdentifier || '',
-      SSO_institutionName: this.state.SSO_institutionName || ''
+      SSO_institutionName: this.state.SSO_institutionName || '',
+      SSO_roleIdentifier: this.state.SSO_roleIdentifier || '',
+      SSO_studentNumberIdentifier: this.state.SSO_studentNumberIdentifier || '',
     })
 
     Meteor.call('settings.update', settings, (e, d) => {
@@ -92,6 +96,8 @@ export class ManageSSO extends Component {
                     <input className='form-control' type='text' data-name='SSO_emailIdentifier' onChange={this.setValue} placeholder='Email Identifier' value={this.state.SSO_emailIdentifier} /><br />
                     <input className='form-control' type='text' data-name='SSO_firstNameIdentifier' onChange={this.setValue} placeholder='First Name Identifier' value={this.state.SSO_firstNameIdentifier} /><br />
                     <input className='form-control' type='text' data-name='SSO_lastNameIdentifier' onChange={this.setValue} placeholder='Last Name Identifier' value={this.state.SSO_lastNameIdentifier} /><br />
+                    <input className='form-control' type='text' data-name='SSO_roleIdentifier' onChange={this.setValue} placeholder='Role Identifier' value={this.state.SSO_roleIdentifier} /><br />
+                    <input className='form-control' type='text' data-name='SSO_studentNumberIdentifier' onChange={this.setValue} placeholder='Student Number Identifier' value={this.state.SSO_studentNumberIdentifier} /><br />
                     IDP certificate (single string, no BEGIN-END)
                     <textarea className='form-control certificate' data-name='SSO_cert' onChange={this.setValue} placeholder='IDP Certificate (single string, no BEGIN-END)' value={this.state.SSO_cert} />
                     SP public certificate (can contain BEGIN-END)

--- a/imports/ui/ManageSSO.jsx
+++ b/imports/ui/ManageSSO.jsx
@@ -28,6 +28,7 @@ export class ManageSSO extends Component {
       SSO_lastNameIdentifier: props.settings.SSO_lastNameIdentifier,
       SSO_roleIdentifier: props.settings.SSO_roleIdentifier,
       SSO_studentNumberIdentifier: props.settings.SSO_studentNumberIdentifier,
+      SSO_roleProfName: props.settings.SSO_roleProfName,
     }
 
     this.setValue = this.setValue.bind(this)
@@ -60,6 +61,7 @@ export class ManageSSO extends Component {
       SSO_institutionName: this.state.SSO_institutionName || '',
       SSO_roleIdentifier: this.state.SSO_roleIdentifier || '',
       SSO_studentNumberIdentifier: this.state.SSO_studentNumberIdentifier || '',
+      SSO_roleProfName: this.state.SSO_roleProfName || '',
     })
 
     Meteor.call('settings.update', settings, (e, d) => {
@@ -97,6 +99,7 @@ export class ManageSSO extends Component {
                     <input className='form-control' type='text' data-name='SSO_firstNameIdentifier' onChange={this.setValue} placeholder='First Name Identifier' value={this.state.SSO_firstNameIdentifier} /><br />
                     <input className='form-control' type='text' data-name='SSO_lastNameIdentifier' onChange={this.setValue} placeholder='Last Name Identifier' value={this.state.SSO_lastNameIdentifier} /><br />
                     <input className='form-control' type='text' data-name='SSO_roleIdentifier' onChange={this.setValue} placeholder='Role Identifier' value={this.state.SSO_roleIdentifier} /><br />
+                    <input className='form-control' type='text' data-name='SSO_roleProfName' onChange={this.setValue} placeholder='Name of professor role for auto-promote' value={this.state.SSO_roleProfName} /><br />
                     <input className='form-control' type='text' data-name='SSO_studentNumberIdentifier' onChange={this.setValue} placeholder='Student Number Identifier' value={this.state.SSO_studentNumberIdentifier} /><br />
                     IDP certificate (single string, no BEGIN-END)
                     <textarea className='form-control certificate' data-name='SSO_cert' onChange={this.setValue} placeholder='IDP Certificate (single string, no BEGIN-END)' value={this.state.SSO_cert} />

--- a/server/main.js
+++ b/server/main.js
@@ -38,7 +38,8 @@ Meteor.startup(() => {
       SSO_lastNameIdentifier:'',
       SSO_institutionName: '',
       SSO_roleIdentifier: '',
-      SSO_studentNumberIdentifier: ''
+      SSO_studentNumberIdentifier: '',
+      SSO_roleProfName: ''
     })
   } else {
     const settings = Settings.findOne()

--- a/server/main.js
+++ b/server/main.js
@@ -36,7 +36,9 @@ Meteor.startup(() => {
       SSO_emailIdentifier: '',
       SSO_firstNameIdentifier: '',
       SSO_lastNameIdentifier:'',
-      SSO_institutionName: ''
+      SSO_institutionName: '',
+      SSO_roleIdentifier: '',
+      SSO_studentNumberIdentifier: ''
     })
   } else {
     const settings = Settings.findOne()
@@ -97,7 +99,7 @@ Meteor.startup(() => {
           'profile.profileThumbnail':thumb}
           })
     }
-    
+
     //console.log(user.profile.lastname)
     if(user.profile.profileImage && !user.profile.profileThumbnail){
       //console.log('   '+user.profile.firstname)

--- a/server/saml_server.js
+++ b/server/saml_server.js
@@ -75,7 +75,9 @@ if(settings && settings.SSO_enabled && settings.SSO_emailIdentifier && settings.
         let services = { sso: {id: samlInfo.nameID,
                                nameIDFormat: samlInfo.nameIDFormat,
                                nameID:samlInfo.nameID,
-                               email: samlProfile.email } }
+                               email: samlProfile.email,
+                               SSORole: samlInfo.SSORole,
+                               studentNumber:samlInfo.studentNumber } }
 
         if(user){//existing user, update their profile
           userId = user._id
@@ -218,9 +220,11 @@ if(settings && settings.SSO_enabled && settings.SSO_emailIdentifier && settings.
             } else {//POST request for login:
               Accounts.samlStrategy._saml.validatePostResponse(req.body, function (err, result) {
                 if (!err) {
-                  email = result[settings.SSO_emailIdentifier] //settings.SSO_emailIdentifier has to be specified (see if at top)
-                  firstname = settings.SSO_firstNameIdentifier ? result[settings.SSO_firstNameIdentifier] : 'Brice'
-                  lastname = settings.SSO_lastNameIdentifier ? result[settings.SSO_lastNameIdentifier] : 'de Nice'
+                  let email = result[settings.SSO_emailIdentifier] //settings.SSO_emailIdentifier has to be specified (see if at top)
+                  let firstname = settings.SSO_firstNameIdentifier ? result[settings.SSO_firstNameIdentifier] : 'Brice'
+                  let lastname = settings.SSO_lastNameIdentifier ? result[settings.SSO_lastNameIdentifier] : 'de Nice'
+                  let SSORole = settings.SSO_roleIdentifier ? result[settings.SSO_roleIdentifier] : ''
+                  let studentNumber = settings.SSO_studentNumberIdentifier ? result[settings.SSO_studentNumberIdentifier] : ''
 
                   profile = {email:email, firstname:firstname, lastname:lastname}
 
@@ -228,6 +232,7 @@ if(settings && settings.SSO_enabled && settings.SSO_emailIdentifier && settings.
                                                                        sessionIndex:result['sessionIndex'],
                                                                        nameID: result.nameID,
                                                                        nameIDFormat: result.nameIDFormat,
+                                                                       SSORole:SSORole, studentNumber:studentNumber
                                                                       } );
 
                   res.writeHead(200, {'Content-Type': 'text/html'});

--- a/server/saml_server.js
+++ b/server/saml_server.js
@@ -93,6 +93,9 @@ if(settings && settings.SSO_enabled && settings.SSO_emailIdentifier && settings.
                                       });
         } else {//new user
           profile.roles = ['student']
+          if (settings.SSO_roleProfName && samlInfo.SSORole && samlInfo.SSORole === settings.SSO_roleProfName){
+            profile.roles = ['professor']
+          }
           userId = Accounts.createUser({
                    email: profile.email,
                    password: Random.secret(),//user will need to reset password to set it to something useful!


### PR DESCRIPTION
- In SSO settings, can specify identifiers for role within the institution and student number
- Can choose to automatically upgrade new users to professor if their institution role matches is equal to a specific string (e.g. if user has role 'faculty', then a professor user is created the first time they log in with SSO)
- SSO only automatically upgrades based on role the first time the user is created, not on subsequent logins.