### PR TITLE
Fix manage group page load error

### DIFF
--- a/imports/api/courses.js
+++ b/imports/api/courses.js
@@ -1159,6 +1159,18 @@ Meteor.methods({
     })
   },
 
+  //TODO Write code to remove students that are left in group arrays after removed from course
+  //Remove missing students from groups
+  /*
+  'courses.cleanGroups' (courseId) {
+    check(courseId, Helpers.MongoID)
+    profHasCoursePermission(courseId)
+    let course = Courses.findOne(courseId)
+    if (!course || !course.groupCategories ) {
+      throw new Meteor.Error('Course does not exist or have groups!')
+    }
+  },*/
+
   // Toggle the course video chat
   // Generates a new random urlId each time it's toggled
   'courses.toggleVideoChat' (courseId) {

--- a/imports/ui/pages/professor/manage_course_groups.jsx
+++ b/imports/ui/pages/professor/manage_course_groups.jsx
@@ -202,6 +202,8 @@ class _ManageCourseGroups extends Component {
         //Need to account for the fact that a student removed from the course
         //could still be listed in a group
         studentsInCategory = studentsInCategory.concat( _(g.students).filter( (s) => {return this.props.students[s]} ) )
+        console.log("studentsInCategory")
+        console.log(studentsInCategory)
       })
     }
 
@@ -260,7 +262,7 @@ class _ManageCourseGroups extends Component {
 
       for ( let igrp = 0; igrp<nGroupsInCat ; igrp++){
 
-        let studentsInGroupCat = groupsInCat[igrp].students
+        let studentsInGroupCat = _(groupsInCat[igrp].students).filter( (s) => {return this.props.students[s]})
         let nStudentsInGroupCat = studentsInGroupCat.length
 
         for (let ist = 0; ist<nStudentsInGroupCat; ist++){

--- a/imports/ui/pages/professor/manage_course_groups.jsx
+++ b/imports/ui/pages/professor/manage_course_groups.jsx
@@ -202,8 +202,6 @@ class _ManageCourseGroups extends Component {
         //Need to account for the fact that a student removed from the course
         //could still be listed in a group
         studentsInCategory = studentsInCategory.concat( _(g.students).filter( (s) => {return this.props.students[s]} ) )
-        console.log("studentsInCategory")
-        console.log(studentsInCategory)
       })
     }
 


### PR DESCRIPTION
The CSV button was not checking that all students in a category are in a course. In some cases, when students are removed from a course, they're not removed from their group. Pro: if they rejoin (eg unenrolled by mistake), they are back in the right group. Con: this type of error. 